### PR TITLE
ci(workflow): add publish workflow (npm packages)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,16 +70,18 @@ jobs:
 
       - name: Publish package
         run: |
+          DATE=$(date +%Y%m%d%H%M%S)
+
           yarn && yarn build
 
           publish=(yarn publish --no-git-tag-version --non-interactive)
 
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
-            :
+            publish+=(--tag latest)
           elif [[ $GITHUB_EVENT_NAME == pull_request ]]; then
-            publish+=(--tag ${{ env.CI_ACTION_REF_NAME_SLUG }})
+            publish+=(--prerelease --preid ${{ env.CI_ACTION_REF_NAME_SLUG }}.$DATE --tag ${{ env.CI_ACTION_REF_NAME_SLUG }})
           else
-            publish+=(--tag next)
+            publish+=(--prerelease --preid next.$DATE --tag next)
           fi
 
           echo "🚀 Publishing npm package with following command line: ${publish[@]}"


### PR DESCRIPTION
Add the job to publish the npm package built to our package registry (https://npm.pkg.github.com).