### PR TITLE
ci(lint): disable dependabot commit linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   lint-commits:
     runs-on: ubuntu-20.04
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Check out repository
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR modifies CI workflow to exclude dependabot's commits linting