### PR TITLE
Ci/publish to GitHub pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,11 @@ name: Publish
 
 on:
   push:
-    branches: [ main ]
-    tags: [ 'v*' ]
+    branches: [main]
+    tags: ['v*']
 
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
   workflow_dispatch:
 
@@ -65,7 +65,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16.14.0
-          registry-url: "https://npm.pkg.github.com"
+          registry-url: 'https://npm.pkg.github.com'
           scope: '@okp4'
 
       - name: Publish package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   publish-docker-images:
     runs-on: ubuntu-20.04
+    concurrency:
+      group: publish-docker-images-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
@@ -53,6 +56,9 @@ jobs:
 
   publish-npm-package:
     runs-on: ubuntu-20.04
+    concurrency:
+      group: publish-npm-package-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Check out repository
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,3 +94,38 @@ jobs:
           "${publish[@]}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+
+  publish-storybook:
+    concurrency:
+      group: publish-storybook-${{ github.ref }}
+      cancel-in-progress: true
+    timeout-minutes: 10
+    runs-on: ubuntu-20.04
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Setup node environment (for publishing)
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.14.0
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@okp4'
+
+      - name: Build storybook
+        run: |
+          yarn
+          yarn build-storybook
+
+      - name: Deploy storybook
+        uses: JamesIves/github-pages-deploy-action@v4.2.5
+        with:
+          branch: gh-pages
+          folder: dist
+          clean: true
+          token: ${{ secrets.OKP4_TOKEN }}
+          git-config-name: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}
+          git-config-email: ${{ secrets.OKP4_BOT_GIT_COMMITTER_EMAIL }}
+          commit-message: |
+            feat: update storybook site (auto)


### PR DESCRIPTION
## Proposal

Now we've made this project public, time has come to publish the generated storybook site to the GitHub pages.

This PR adds a job to deploy the [storybook](https://storybook.js.org) to [GitHub Pages](https://pages.github.com/) using the GitHub Action [github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action), under the identity of @bot-anik.

The deployment is triggered on the `main` branch in order to reflect the latest changes and committed on the branch [gh-pages](https://github.com/okp4/ui/tree/gh-pages).

The storybook will be accessible at the following URL: https://okp4.github.io/ui/.