### PR TITLE
ci(workflow): modify dependabot schedule execution

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: weekly
     reviewers:
       - arnaudmimart
       - ccamel
@@ -13,9 +13,9 @@ updates:
       - fredericvilcot
     open-pull-requests-limit: 5
   - package-ecosystem: npm
-    directory: "/"
+    directory: /
     schedule:
-      interval: daily
+      interval: weekly
     reviewers:
       - arnaudmimart
       - ccamel


### PR DESCRIPTION
This PR makes dependabot run once a week instead of once a day.