### PR TITLE
Ci/release tuning

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,7 @@ jobs:
         uses: avto-dev/markdown-lint@v1.5.0
         with:
           args: '**/*.md'
+          ignore: "./CHANGELOG.md"
 
   lint-yaml:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,7 +100,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
 
   publish-npm-package-public:
-    if: github.event_name == 'tags'
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     concurrency:
       group: publish-npm-package-public-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git
+            @semantic-release/npm
         env:
           GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -7,8 +7,12 @@ plugins:
   - - "@semantic-release/changelog"
     - changelogFile: CHANGELOG.md
       changelogTitle: "# ØKP4 UI changelog"
+  - - "@semantic-release/npm"
+    - npmPublish: false
+      tarballDir: false
   - "@semantic-release/github"
   - - "@semantic-release/git"
     - assets:
         - CHANGELOG.md
+        - package.json
       message: "chore(release): perform release ${nextRelease.version}"


### PR DESCRIPTION
Little tuning on the CI:
- Properly trigger npm public publish on tag push
- Ignore `CHANGELOG.md` from linter
- Set and Commit `package.json` release version