### PR TITLE
ci(build): ensure yarn.lock is up-to-date

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          yarn
+          yarn --frozen-lockfile
 
       - name: Build project
         run: |


### PR DESCRIPTION
## Purpose

This PRs ensures that `yarn.lock` file is in sync with `package.json` file during the `build`.

## Rationale

It's quite obvious. The CI here ensures that the `yarn.lock` file has been updated and committed with the `package.json` file.

## Links

- [yarn --frozen-lockfile](https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-frozen-lockfile)