### PR TITLE
chore: generating typescript definitions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
+    "declaration": true,
+    "declarationDir": "lib",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,


### PR DESCRIPTION
Typescript definitions were not included in the npm package.

This PR https://github.com/okp4/ui/pull/77 but with the right branch name.