### PR TITLE
ci: add codeclimate initial configuration

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,11 @@
+version: '2'
+exclude_patterns:
+  - '**/*.d.ts'
+  - '**/*.spec.ts'
+plugins:
+  duplication:
+    enabled: true
+    config:
+      languages:
+        typescript:
+          mass_threshold: 200

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
 
       - name: Test typescript
         run: |
-          yarn jest
+          yarn coverage

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "lint:fix": "eslint --fix './src/**/*.{js,jsx,ts,tsx}'",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook -o dist/",
-    "test": "jest"
+    "test": "jest",
+    "coverage": "yarn test --coverage --watchAll=false --silent --ci"
   },
   "keywords": [],
   "peerDependencies": {


### PR DESCRIPTION
Codeclimate is a great tool but a little bit too strict for us with the default configuration. This PR proposes a configuration that relaxes some constraints.