### PR TITLE
test: add specification for HTTPFaucetGateway

### DIFF
--- a/src/adapters/faucet/secondary/HTTPFaucetGateway.spec.ts
+++ b/src/adapters/faucet/secondary/HTTPFaucetGateway.spec.ts
@@ -1,0 +1,43 @@
+import axios from 'axios'
+import { UnspecifiedError } from 'domain/wallet/entities/errors'
+import { HTTPFaucetGateway } from './HTTPFaucetGateway'
+
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>
+const testUrl = 'http://my-test-fake-url.com'
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('Given an HTTPFaucetGateway instance', () => {
+  const gateway = new HTTPFaucetGateway(testUrl)
+  describe('When requesting funds', () => {
+    mockedAxios.get.mockResolvedValueOnce(testUrl)
+    test('Then expect the HTTPFaucetGateway to succeed', async () => {
+      const result = await gateway.requestFunds(testUrl)
+      expect(mockedAxios.get).toHaveBeenCalledWith(testUrl, {
+        params: {
+          address: testUrl
+        }
+      })
+      expect(result).toEqual(undefined)
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+describe('Given an HTTPFaucetGateway instance', () => {
+  const gateway = new HTTPFaucetGateway(testUrl)
+  describe('When requesting funds', () => {
+    const error = new UnspecifiedError(
+      'Oooops... An unspecified error occured while requesting funds..'
+    )
+    mockedAxios.get.mockRejectedValueOnce(error)
+    test('Then expect the HTTPFaucetGateway to fail', async () => {
+      const result = gateway.requestFunds(testUrl)
+      await expect(result).rejects.toEqual(error)
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/adapters/faucet/secondary/HTTPFaucetGateway.spec.ts
+++ b/src/adapters/faucet/secondary/HTTPFaucetGateway.spec.ts
@@ -12,46 +12,59 @@ afterEach(() => {
 
 describe('Given an HTTPFaucetGateway instance', () => {
   const gateway = new HTTPFaucetGateway(testUrl)
-  describe('When Axios returns a response ', () => {
-    mockedAxiosGet.mockResolvedValueOnce(testUrl)
-    test('Then expect requestFunds to succeed', async () => {
-      const result = await gateway.requestFunds(testUrl)
-      expect(mockedAxiosGet).toHaveBeenCalledWith(testUrl, {
-        params: {
-          address: testUrl
-        }
+
+  describe('And an axios client returning a success value', () => {
+    mockedAxiosGet.mockResolvedValueOnce(undefined)
+
+    describe('When requesting funds', () => {
+      test('Then expect the call to succeed', async () => {
+        const result = await gateway.requestFunds(testUrl)
+        expect(mockedAxiosGet).toHaveBeenCalledWith(testUrl, {
+          params: {
+            address: testUrl
+          }
+        })
+        expect(result).toEqual(undefined)
+        expect(mockedAxiosGet).toHaveBeenCalledTimes(1)
       })
-      expect(result).toEqual(undefined)
-      expect(mockedAxiosGet).toHaveBeenCalledTimes(1)
     })
   })
 })
 
 describe('Given an HTTPFaucetGateway instance', () => {
   const gateway = new HTTPFaucetGateway(testUrl)
-  describe('When Axios fails with an AxiosError ', () => {
+
+  describe('And an axios client returning an Axios error', () => {
     const error = new Error('Network Error') as AxiosError
     error.isAxiosError = true
     mockedAxiosGet.mockRejectedValueOnce(error)
-    test('Then expect requestFunds to throw a GatewayError', async () => {
-      const gatewayError = new GatewayError('Network Error')
-      const result = gateway.requestFunds(testUrl)
-      await expect(result).rejects.toEqual(gatewayError)
-      await expect(result).rejects.toThrow(gatewayError)
-      expect(mockedAxiosGet).toHaveBeenCalledTimes(1)
+
+    describe('When requesting funds', () => {
+      test('Then expect the call to throw a GatewayError', async () => {
+        const result = gateway.requestFunds(testUrl)
+
+        const gatewayError = new GatewayError('Network Error')
+        await expect(result).rejects.toEqual(gatewayError)
+        await expect(result).rejects.toThrow(gatewayError)
+        expect(mockedAxiosGet).toHaveBeenCalledTimes(1)
+      })
     })
   })
-  describe('When Axios fails with a non AxiosError ', () => {
+
+  describe('And an axios client returns a non Axios error', () => {
     const error = new Error()
     mockedAxiosGet.mockRejectedValueOnce(error)
-    test('Then expect requestFunds to throw a UnspecifiedError', async () => {
-      const unspecifiedError = new UnspecifiedError(
-        'Oooops... An unspecified error occured while requesting funds..'
-      )
-      const result = gateway.requestFunds(testUrl)
-      await expect(result).rejects.toEqual(unspecifiedError)
-      await expect(result).rejects.toThrow(unspecifiedError)
-      expect(mockedAxiosGet).toHaveBeenCalledTimes(1)
+
+    describe('When requesting funds', () => {
+      test('Then expect the call to throw a UnspecifiedError', async () => {
+        const unspecifiedError = new UnspecifiedError(
+          'Oooops... An unspecified error occured while requesting funds..'
+        )
+        const result = gateway.requestFunds(testUrl)
+        expect(result).rejects.toEqual(unspecifiedError)
+        expect(result).rejects.toThrow(unspecifiedError)
+        expect(mockedAxiosGet).toHaveBeenCalledTimes(1)
+      })
     })
   })
 })


### PR DESCRIPTION
This PR adds test suite for `HTTPFaucetGateway` to be sure that `requestFunds` method is well covered (success / error)

Gives a 100% coverage for the `HTTPFaucetGateway`: 

<img width="736" alt="image" src="https://user-images.githubusercontent.com/47554752/163559019-626098ac-a6f2-413c-80f0-05dc4ae0063d.png">
