### PR TITLE
fix: wrap Gotham black fontWeight into quotes

### DIFF
--- a/src/ui/atoms/typography/typography.scss
+++ b/src/ui/atoms/typography/typography.scss
@@ -32,7 +32,7 @@ $weights: (
             font-family: Noto Sans Mono, sans-serif;
             font-weight: $weight-value;
           } @else {
-            font-family: Gotham #{$weight-key}, sans-serif;
+            font-family: 'Gotham #{$weight-key}', sans-serif;
             @if ($weight-key == 'bold') {
               font-family: Gotham, sans-serif;
               font-weight: 700;


### PR DESCRIPTION
This PR ensures that `black` property is correctly added to `Gotham` font family.