### PR TITLE
Ci/fix coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,3 @@ jobs:
         with:
           files: ./coverage/lcov.info
           verbose: true
-
-      - name: Comment test coverage on pull request
-        uses: ArtiomTr/jest-coverage-report-action@v2
-        if: github.actor != 'dependabot[bot]'
-        with:
-          package-manager: yarn
-          test-script: yarn coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: codecov/codecov-action@v2
         if: github.actor != 'dependabot[bot]'
         with:
-          files: ./coverage/clover.xml
+          files: ./coverage/lcov.info
           verbose: true
 
       - name: Comment test coverage on pull request


### PR DESCRIPTION
The `clover.xml` coverage report uploaded to codecov seems to consider missing `else` execution paths as uncovered paths: https://github.com/huggingface/transformers/issues/6317

Let's swith to the `lcov.info` format.

Also removed the manual PR coverage comment as it is already done by Codecov.