### PR TITLE
chore: add .idea folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 lib/
 node_modules/
 coverage/
+.idea/


### PR DESCRIPTION
This PR ensures that `.idea` folder that contains `idea` configuration files is correctly ignored from `git`.