### PR TITLE
feat/event-metadata

### DIFF
--- a/src/adapters/error/primary/eventListeners.ts
+++ b/src/adapters/error/primary/eventListeners.ts
@@ -8,6 +8,6 @@ export const initErrorEventListeners = (
   store: DeepReadonly<ReduxStore>,
   eventBus: DeepReadonly<EventBus>
 ): (() => void) =>
-  eventBus.subscribe('error/errorThrown', (event: ErrorThrownEvent) => {
-    store.dispatch(reportError(event.payload))
+  eventBus.subscribe('error/errorThrown', (event: DeepReadonly<ErrorThrownEvent>) => {
+    store.dispatch(reportError({ ...event.payload, initiator: event.meta.initiator }))
   })

--- a/src/adapters/faucet/primary/eventListeners.ts
+++ b/src/adapters/faucet/primary/eventListeners.ts
@@ -5,9 +5,12 @@ import type { ReduxStore } from 'domain/faucet/store/store'
 import type { DeepReadonly } from 'superTypes'
 
 export const initFaucetEventListeners = (store: DeepReadonly<ReduxStore>): (() => void) =>
-  eventBus.subscribe('wallet/accountsRetrieved', (event: WalletAccountsRetrievedEvent) => {
-    const address = event.payload.accounts.get(0)?.address
-    if (address) {
-      store.dispatch(setAddress(address))
+  eventBus.subscribe(
+    'wallet/accountsRetrieved',
+    (event: DeepReadonly<WalletAccountsRetrievedEvent>) => {
+      const address = event.payload.accounts.get(0)?.address
+      if (address) {
+        store.dispatch(setAddress(address))
+      }
     }
-  })
+  )

--- a/src/domain/common/actionCreators.ts
+++ b/src/domain/common/actionCreators.ts
@@ -2,6 +2,7 @@
 import type { Error } from 'domain/error/entity/error'
 import type { ActionsUnion } from 'domain/common/store.helper'
 import { createAction } from 'domain/common/store.helper'
+import type { TypedBusEvent } from 'eventBus/eventBus'
 import type { DeepReadonly } from 'superTypes'
 
 export const ThrowErrorActions = {
@@ -9,4 +10,6 @@ export const ThrowErrorActions = {
 }
 
 export type ThrowErrorActionTypes = ActionsUnion<typeof ThrowErrorActions>
-export type ErrorThrownEvent = DeepReadonly<ReturnType<typeof ThrowErrorActions['errorThrown']>>
+export type ErrorThrownEvent = TypedBusEvent<
+  DeepReadonly<ReturnType<typeof ThrowErrorActions['errorThrown']>>
+>

--- a/src/domain/common/store.helper.ts
+++ b/src/domain/common/store.helper.ts
@@ -1,6 +1,7 @@
 import type { Action, Middleware, Dispatch, AnyAction } from 'redux'
-import type { DeepReadonly } from 'superTypes'
 import type { EventBus } from 'ts-bus'
+import type { EventMetadata } from 'eventBus/eventBus'
+import type { DeepReadonly } from 'superTypes'
 
 export interface ActionWithPayload<T extends string, P> extends Action<T> {
   readonly payload: P
@@ -21,14 +22,18 @@ type ActionCreatorsMapObject = Record<string, FunctionType>
 
 export type ActionsUnion<A extends ActionCreatorsMapObject> = ReturnType<A[keyof A]>
 
-export function eventBusMiddleware(eventBus: DeepReadonly<EventBus>): Middleware {
+export function eventBusMiddleware(
+  eventBus: DeepReadonly<EventBus>,
+  initiator: string
+): Middleware {
   return function () {
     return function (next: Dispatch<AnyAction>) {
       // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
       return function (action: DeepReadonly<Action<string> | ActionWithPayload<string, unknown>>) {
         const payload = (action as ActionWithPayload<string, unknown>).payload || null
         const event = { type: action.type, payload: payload }
-        eventBus.publish(event)
+        const metadata: EventMetadata = { timestamp: new Date(), initiator }
+        eventBus.publish(event, metadata)
         return next(action)
       }
     }

--- a/src/domain/error/builder/error.builder.spec.ts
+++ b/src/domain/error/builder/error.builder.spec.ts
@@ -11,6 +11,7 @@ type Data = Readonly<
     timestamp: Readonly<Date>
     messageKey: string
     type: string
+    initiator: string
     context: DeepReadonly<Record<string, unknown>>
   }> & {
     expectedStatus: boolean
@@ -35,20 +36,30 @@ describe('Build an error', () => {
   })
 
   describe.each`
-    initialError          | id           | timestamp    | messageKey                         | type                  | context           | expectedStatus
-    ${undefined}          | ${'#id1'}    | ${aDate}     | ${'domain.error.validation-error'} | ${'validation-error'} | ${{}}             | ${true}
-    ${undefined}          | ${'#id2'}    | ${aDate}     | ${'domain.error.validation-error'} | ${'validation-error'} | ${{ foo: 'bar' }} | ${true}
-    ${undefined}          | ${'#id3'}    | ${aDate}     | ${'domain.error.validation-error'} | ${'validation-error'} | ${null}           | ${true}
-    ${undefined}          | ${undefined} | ${aDate}     | ${'domain.error.validation-error'} | ${'validation-error'} | ${{}}             | ${true}
-    ${undefined}          | ${'#id5'}    | ${undefined} | ${'domain.error.validation-error'} | ${'validation-error'} | ${{}}             | ${true}
-    ${undefined}          | ${''}        | ${aDate}     | ${'domain.error.validation-error'} | ${'validation-error'} | ${{}}             | ${false}
-    ${undefined}          | ${'#id7'}    | ${aDate}     | ${''}                              | ${'validation-error'} | ${{}}             | ${false}
-    ${undefined}          | ${'#id8'}    | ${aDate}     | ${'domain.error.validation-error'} | ${''}                 | ${{}}             | ${false}
-    ${{ messageKey: '' }} | ${'#id8'}    | ${undefined} | ${undefined}                       | ${undefined}          | ${{}}             | ${false}
-    ${undefined}          | ${'#id8'}    | ${aBadDate}  | ${'domain.error.validation-error'} | ${''}                 | ${{}}             | ${false}
+    initialError          | id           | timestamp    | messageKey                         | type                  | initiator | context           | expectedStatus
+    ${undefined}          | ${'#id1'}    | ${aDate}     | ${'domain.error.validation-error'} | ${'validation-error'} | ${'test'} | ${{}}             | ${true}
+    ${undefined}          | ${'#id2'}    | ${aDate}     | ${'domain.error.validation-error'} | ${'validation-error'} | ${'test'} | ${{ foo: 'bar' }} | ${true}
+    ${undefined}          | ${'#id3'}    | ${aDate}     | ${'domain.error.validation-error'} | ${'validation-error'} | ${'test'} | ${null}           | ${true}
+    ${undefined}          | ${undefined} | ${aDate}     | ${'domain.error.validation-error'} | ${'validation-error'} | ${'test'} | ${{}}             | ${true}
+    ${undefined}          | ${'#id5'}    | ${undefined} | ${'domain.error.validation-error'} | ${'validation-error'} | ${'test'} | ${{}}             | ${true}
+    ${undefined}          | ${''}        | ${aDate}     | ${'domain.error.validation-error'} | ${'validation-error'} | ${'test'} | ${{}}             | ${false}
+    ${undefined}          | ${'#id7'}    | ${aDate}     | ${''}                              | ${'validation-error'} | ${'test'} | ${{}}             | ${false}
+    ${undefined}          | ${'#id8'}    | ${aDate}     | ${'domain.error.validation-error'} | ${''}                 | ${'test'} | ${{}}             | ${false}
+    ${{ messageKey: '' }} | ${'#id8'}    | ${undefined} | ${undefined}                       | ${undefined}          | ${'test'} | ${{}}             | ${false}
+    ${undefined}          | ${'#id8'}    | ${aBadDate}  | ${'domain.error.validation-error'} | ${''}                 | ${'test'} | ${{}}             | ${false}
+    ${undefined}          | ${'#id8'}    | ${aDate}     | ${'domain.error.validation-error'} | ${'validation-error'} | ${''}     | ${{}}             | ${false}
   `(
-    'Given that id is <$id>, timestamp is <$timestamp>, messageKey is <$messageKey>, type is <$type> and context is <$context>',
-    ({ initialError, id, timestamp, messageKey, type, context, expectedStatus }: Data) => {
+    'Given that id is <$id>, timestamp is <$timestamp>, messageKey is <$messageKey>, type is <$type>, initiator is <$initiator> and context is <$context>',
+    ({
+      initialError,
+      id,
+      timestamp,
+      messageKey,
+      type,
+      initiator,
+      context,
+      expectedStatus
+    }: Data) => {
       describe('When building error', () => {
         const error = (): Error => {
           // eslint-disable-next-line functional/no-let
@@ -66,6 +77,9 @@ describe('Build an error', () => {
           if (type !== undefined) {
             errorBuilder = errorBuilder.withType(type)
           }
+          if (initiator !== undefined) {
+            errorBuilder = errorBuilder.withInitiator(initiator)
+          }
           if (context !== undefined) {
             errorBuilder = errorBuilder.withContext(context)
           }
@@ -79,6 +93,7 @@ describe('Build an error', () => {
               timestamp: timestamp === undefined ? fakedDate : timestamp,
               messageKey,
               type,
+              initiator,
               context: !context || !Object.keys(context).length ? {} : context
             })
           } else {

--- a/src/domain/error/builder/error.builder.ts
+++ b/src/domain/error/builder/error.builder.ts
@@ -48,6 +48,13 @@ export class ErrorBuilder {
     return new ErrorBuilder({ ...this.error, type })
   }
 
+  public withInitiator(initiator: string): ErrorBuilder {
+    if (!initiator.length) {
+      throw new UnspecifiedError('Ooops... An initiator must be provided to build an error...')
+    }
+    return new ErrorBuilder({ ...this.error, initiator })
+  }
+
   public withContext(context?: DeepReadonly<Record<string, unknown>>): ErrorBuilder {
     if (!context) {
       return this
@@ -67,7 +74,8 @@ export class ErrorBuilder {
       this.error.id.length > 0 &&
       this.error.timestamp instanceof Date &&
       this.error.type.length > 0 &&
-      this.error.messageKey.length > 0
+      this.error.messageKey.length > 0 &&
+      (this.error.initiator ? this.error.initiator.length > 0 : true)
     )
   }
 }

--- a/src/domain/error/entity/error.ts
+++ b/src/domain/error/entity/error.ts
@@ -7,6 +7,7 @@ export type Error = Entity<
     readonly messageKey: string
     readonly timestamp: Date
     readonly type: string
+    readonly initiator?: string
     readonly context?: Record<string, unknown>
   },
   Id

--- a/src/domain/error/store/store.ts
+++ b/src/domain/error/store/store.ts
@@ -17,7 +17,10 @@ export const configureStore = (
     rootReducer,
     preloadedState,
     composeWithDevTools(
-      applyMiddleware(thunk as ThunkMiddleware<AppState, Action>, eventBusMiddleware(eventBus))
+      applyMiddleware(
+        thunk as ThunkMiddleware<AppState, Action>,
+        eventBusMiddleware(eventBus, 'domain:error')
+      )
     )
   )
 

--- a/src/domain/faucet/store/store.ts
+++ b/src/domain/faucet/store/store.ts
@@ -22,7 +22,7 @@ export const configureStore = (
     composeWithDevTools(
       applyMiddleware(
         thunk.withExtraArgument(dependencies) as ThunkMiddleware<AppState, Action, Dependencies>,
-        eventBusMiddleware(eventBus)
+        eventBusMiddleware(eventBus, 'domain:faucet')
       )
     )
   )

--- a/src/domain/faucet/usecase/request-funds/requestFunds.spec.ts
+++ b/src/domain/faucet/usecase/request-funds/requestFunds.spec.ts
@@ -17,6 +17,7 @@ interface Data {
   address: string
   expectedPayloadType: string
   expectedPayloadMessageKey: string
+  expectedMetaInitiator: string
   expectedHaveBeenCalledTimes: number
 }
 
@@ -52,10 +53,10 @@ describe('Request funds from faucet', () => {
     }
 
   describe.each`
-    hasGatewayError | address                                            | expectedPayloadType   | expectedPayloadMessageKey          | expectedHaveBeenCalledTimes
-    ${false}        | ${'123'}                                           | ${'validation-error'} | ${'domain.error.validation-error'} | ${1}
-    ${false}        | ${'cosmos196877dj4crpxmja2ww2hj2vgy45v6uspm7nrmy'} | ${'validation-error'} | ${'domain.error.validation-error'} | ${1}
-    ${true}         | ${'okp4196877dj4crpxmja2ww2hj2vgy45v6uspkzkt8l'}   | ${'gateway-error'}    | ${'domain.error.gateway-error'}    | ${2}
+    hasGatewayError | address                                            | expectedPayloadType   | expectedPayloadMessageKey          | expectedMetaInitiator | expectedHaveBeenCalledTimes
+    ${false}        | ${'123'}                                           | ${'validation-error'} | ${'domain.error.validation-error'} | ${'domain:faucet'}    | ${1}
+    ${false}        | ${'cosmos196877dj4crpxmja2ww2hj2vgy45v6uspm7nrmy'} | ${'validation-error'} | ${'domain.error.validation-error'} | ${'domain:faucet'}    | ${1}
+    ${true}         | ${'okp4196877dj4crpxmja2ww2hj2vgy45v6uspkzkt8l'}   | ${'gateway-error'}    | ${'domain.error.gateway-error'}    | ${'domain:faucet'}    | ${2}
   `(
     'Given that hasGatewayError is <$hasGatewayError> and address is <$address>',
     ({
@@ -63,6 +64,7 @@ describe('Request funds from faucet', () => {
       address,
       expectedPayloadType,
       expectedPayloadMessageKey,
+      expectedMetaInitiator,
       expectedHaveBeenCalledTimes
     }: Readonly<Data>): void => {
       const { store, faucetGateway }: InitialProps = init()
@@ -78,6 +80,9 @@ describe('Request funds from faucet', () => {
                 type: expectedPayloadType,
                 messageKey: expectedPayloadMessageKey
               })
+            }),
+            expect.objectContaining({
+              initiator: expectedMetaInitiator
             })
           )
         })

--- a/src/domain/wallet/store/store.ts
+++ b/src/domain/wallet/store/store.ts
@@ -23,7 +23,7 @@ export const configureStore = (
     composeWithDevTools(
       applyMiddleware(
         thunk.withExtraArgument(dependencies) as ThunkMiddleware<AppState, Action, Dependencies>,
-        eventBusMiddleware(eventBus)
+        eventBusMiddleware(eventBus, 'domain:wallet')
       )
     )
   )

--- a/src/domain/wallet/type/event.type.ts
+++ b/src/domain/wallet/type/event.type.ts
@@ -1,9 +1,10 @@
+import type { TypedBusEvent } from 'eventBus/eventBus'
 import type { DeepReadonly } from 'superTypes'
 import type { EnableWalletActions } from '../usecases/enable-wallet/actionCreators'
 
 export type WalletConnectedEvent = DeepReadonly<
   ReturnType<typeof EnableWalletActions['walletConnected']>
 >
-export type WalletAccountsRetrievedEvent = DeepReadonly<
-  ReturnType<typeof EnableWalletActions['accountsRetrieved']>
+export type WalletAccountsRetrievedEvent = TypedBusEvent<
+  DeepReadonly<ReturnType<typeof EnableWalletActions['accountsRetrieved']>>
 >

--- a/src/eventBus/eventBus.ts
+++ b/src/eventBus/eventBus.ts
@@ -1,3 +1,11 @@
 import { EventBus } from 'ts-bus'
+import type { BusEvent } from 'ts-bus/types'
+
+export type EventMetadata = {
+  timestamp: Date
+  initiator: string
+}
+
+export type TypedBusEvent<T> = Omit<Omit<BusEvent, 'payload'>, 'meta'> & { meta: EventMetadata } & T
 
 export const eventBus = new EventBus()


### PR DESCRIPTION
This PR comes to enhance event management by providing an additional `metadata` parameter to `publish` method.
For now, metadata carries 2 properties : `initiator` and `timestamp`.
`metadata` is always provided thanks to redux `eventBus` middleware but its use is optional in `reducers`.
