### PR TITLE
ci(workflow): add "lint" for branch name conventions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -87,3 +87,41 @@ jobs:
         uses: hiwelo/new-dependencies-action@1.0.1
         with:
           token: ${{ secrets.OKP4_TOKEN }}
+
+  lint-branch-name:
+    runs-on: ubuntu-20.04
+    if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    steps:
+      - name: Check branch name conventions
+        uses: AlbertHernandez/branch-name-action@v1.0.2
+        with:
+          branch_pattern: "feat|fix|build|ci|docs|style|refactor|perf|test|chore"
+          comment_for_invalid_branch_name: |
+            🙋‍ Oops! This branch name does not follow the naming convention.
+
+            <hr>
+
+            Please, see the following branch naming convention:
+
+            Branch naming convention | Purpose
+            ------------------------ | -------
+            `feat/**`                | A new feature
+            `fix/**`                 | A bug fix
+            `build/**`               | Changes that affect the build system (npm, mavem, poetry)
+            `ci/**`                  | Changes to the CI configuration
+            `docs/**`                | Documentation only changes
+            `style/**`               | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+            `refactor/**`            | Code changes that neither fixe a bug nor adds a feature
+            `perf/**`                | Code changes that improve performance
+            `test/**`                | When adding tests or correcting existing tests
+            `chore/**`               | Other changes that don't modify source
+          fail_if_invalid_branch_name: "true"
+          ignore_branch_pattern: "main"
+      - name: Close non-compliant branch
+        if: ${{ failure() }}
+        uses: codelytv/no-pull-requests@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}
+          message: 🙅 Closing the PR because it does not respect naming conventions. Edit the branch name and submit a new PR.
+    env:
+      GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}


### PR DESCRIPTION
Let @bot-anik verify that opened PRs follow our naming conventions, and close them if not (the branch is still opened).