### PR TITLE
fix(card): increase padding size due to polygon

### DIFF
--- a/src/ui/atoms/card/card.scss
+++ b/src/ui/atoms/card/card.scss
@@ -12,9 +12,9 @@ $sizes-map: (
   small-height: 235px,
   medium-height: 235px,
   large-height: 550px,
-  small-padding: 16px,
-  medium-padding: 26px,
-  large-padding: 34px
+  small-padding: 30px,
+  medium-padding: 35px,
+  large-padding: 40px
 );
 
 .okp4-card-main {


### PR DESCRIPTION
This PR implements these following specifications: https://github.com/okp4/ui/issues/237
The top left card corner measures 30px soit we have to set the padding by at least this size.