### PR TITLE
build(project): exit the build with an error if warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c --failAfterWarnings",
     "clean": "rimraf dist",
     "lint": "eslint './src/**/*.{js,jsx,ts,tsx}' --max-warnings=0 && stylelint './src/**/*.scss'",
     "lint:fix": "eslint --fix './src/**/*.{js,jsx,ts,tsx}'",

--- a/src/domain/faucet/type/event.type.ts
+++ b/src/domain/faucet/type/event.type.ts
@@ -1,12 +1,4 @@
 import type { DeepReadonly } from 'superTypes'
-import type { RequestFundsActions } from '../usecase/request-funds/actionCreators'
 import type { SetAddressActions } from '../usecase/set-address/actionCreators'
 
 export type FaucetAddressSetEvent = DeepReadonly<ReturnType<typeof SetAddressActions['addressSet']>>
-
-export type RequestFundsProceededEvent = DeepReadonly<
-  ReturnType<typeof RequestFundsActions['requestFundsProceeded']>
->
-export type RequestFundsSucceededEvent = DeepReadonly<
-  ReturnType<typeof RequestFundsActions['requestFundsSucceeded']>
->


### PR DESCRIPTION
Add the option [--failAfterWarnings](https://rollupjs.org/guide/en/#--failafterwarnings) to [rollup.js](https://rollupjs.org/) during build.

This prevents this kind of errors that are not (currently) halted by the build:

```
(!) Plugin typescript: @rollup/plugin-typescript TS2307: Cannot find module '../usecase/request-funds/actionCreators' or its corresponding type declarations.
src/domain/faucet/type/event.type.ts: (2:42)
2 import type { RequestFundsActions } from '../usecase/request-funds/actionCreators'
                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```