### PR TITLE
fix: add images copy into rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -44,7 +44,8 @@ export default [
               'src/ui/styles/_exports.module.scss'
             ],
             dest: 'lib/scss'
-          }
+          },
+          { src: 'src/assets/images', dest: 'lib/assets/images' }
         ],
         verbose: true
       }),


### PR DESCRIPTION
self explanatory