### PR TITLE
Ci/refine tunings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-yarn:
     runs-on: ubuntu-20.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Check for new dependencies
         uses: hiwelo/new-dependencies-action@1.0.1
         with:
-          token: ${{ secrets.OKP4_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   lint-branch-name:
     runs-on: ubuntu-20.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-commits:
     runs-on: ubuntu-20.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,13 +53,6 @@ jobs:
       - name: Lint dockerfile (hadolint)
         uses: hadolint/hadolint-action@v2.1.0
 
-      - name: Lint dockerfile (docker-lint)
-        uses: luke142367/Docker-Lint-Action@v1.1.1
-        with:
-          target: Dockerfile
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   lint-ts:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,71 +55,39 @@ jobs:
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
 
-  publish-npm-package-okp4:
+  publish-npm-package:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        registry:
+          - url: "https://npm.pkg.github.com"
+            auth-token-secret: NPM_REGISTRY_TOKEN
+          - url: "https://registry.npmjs.org"
+            auth-token-secret: NPM_PUBLIC_REGISTRY_TOKEN
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-
-      - name: Set up context
-        id: project_context
-        uses: FranzDiebold/github-env-vars-action@v2.3.1
 
       - name: Setup node environment (for publishing)
         uses: actions/setup-node@v3
         with:
           node-version: 16.14.0
-          registry-url: "https://npm.pkg.github.com"
+          registry-url: ${{ matrix.registry.url }}
           scope: "@okp4"
 
       - name: Publish package
         run: |
           DATE=$(date +%Y%m%d%H%M%S)
-
-          yarn && yarn build
-
-          publish=(yarn publish --no-git-tag-version --non-interactive)
-
+          publish=(yarn publish --access=public --no-git-tag-version --non-interactive)
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             publish+=(--tag latest)
           else
             publish+=(--prerelease --preid next.$DATE --tag next)
           fi
-
           echo "🚀 Publishing npm package with following command line: ${publish[@]}"
           "${publish[@]}"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
-
-  publish-npm-package-public:
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-
-      - name: Set up context
-        id: project_context
-        uses: FranzDiebold/github-env-vars-action@v2.3.1
-
-      - name: Setup node environment (for publishing)
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.14.0
-          registry-url: "https://registry.npmjs.org"
-          scope: "@okp4"
-
-      - name: Publish package
-        run: |
-          yarn && yarn build
-
-          publish=(yarn publish --access=public --no-git-tag-version --non-interactive)
-          publish+=(--tag latest)
-
-          echo "🚀 Publishing npm package with following command line: ${publish[@]}"
-          "${publish[@]}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLIC_REGISTRY_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets[matrix.registry.auth-token-secret] }}
 
   publish-storybook:
     timeout-minutes: 10

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,6 @@ concurrency:
 jobs:
   publish-docker-images:
     runs-on: ubuntu-20.04
-    if: github.event_name != 'pull_request'
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -34,7 +33,7 @@ jobs:
           labels: |
             org.opencontainers.image.vendor=OKP4
 
-      - name: Login to OKP4 Docker registry
+      - name: Login to GHCR
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,13 +5,14 @@ on:
     branches: [main]
     tags: ["v*"]
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish-docker-images:
     runs-on: ubuntu-20.04
     if: github.event_name != 'pull_request'
-    concurrency:
-      group: publish-docker-images-${{ github.ref }}
-      cancel-in-progress: true
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -57,9 +58,6 @@ jobs:
 
   publish-npm-package-okp4:
     runs-on: ubuntu-20.04
-    concurrency:
-      group: publish-npm-package-okp4-${{ github.ref }}
-      cancel-in-progress: true
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -97,9 +95,6 @@ jobs:
   publish-npm-package-public:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
-    concurrency:
-      group: publish-npm-package-public-${{ github.ref }}
-      cancel-in-progress: true
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -128,9 +123,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLIC_REGISTRY_TOKEN }}
 
   publish-storybook:
-    concurrency:
-      group: publish-storybook-${{ github.ref }}
-      cancel-in-progress: true
     timeout-minutes: 10
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,16 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.actor == 'bot-anik'
     uses: ./.github/workflows/build.yml
 
+  test:
+    if: github.ref == 'refs/heads/main' && github.actor == 'bot-anik'
+    uses: ./.github/workflows/test.yml
+
   perfom-release:
     if: github.ref == 'refs/heads/main' && github.actor == 'bot-anik'
     needs:
       - lint
       - build
+      - test
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-ts:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Bring multiple refinements, improvements to CI flows.

## PR from forks

Following https://github.com/okp4/ui/pull/281 some checks were failing due to the secrets available when running actions, when running actions on PR referencing forked head ref we shall avoid referencing organization specific tokens.

**Fix `report-new-dependencies` job:**

Replace the usage of an OKP4 specific token in favor of the default one, which should suffice to comment a PR.

**Fix `lint-dockerfile` job:**

The [luke142367/Docker-Lint-Action](https://github.com/luke142367/Docker-Lint-Action) posting annotations on changes, it needs a token with repository access, which is impossible running from forks. As this linter seems to me less rigid than hadolint, I propose to simply remove it.

## Publish

Publish `next` versions to npm public registry as well, take the opportunity to use matrix job to share the logic with the Github Packages publication.

## Misc

- Prevent the release workflow from running with failing tests.
- Add some concurrency handling.