### PR TITLE
fix: remove images from destination path

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,7 +45,7 @@ export default [
             ],
             dest: 'lib/scss'
           },
-          { src: 'src/assets/images', dest: 'lib/assets/images' }
+          { src: 'src/assets/images', dest: 'lib/assets' }
         ],
         verbose: true
       }),


### PR DESCRIPTION
`images`must be remove from the destination path `{ src: 'src/assets/images', dest: 'lib/assets/images' }` otherwise there will be a duplication of `images`folder in the lib.