### PR TITLE
ci(publish): build package before publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,6 +77,7 @@ jobs:
 
       - name: Publish package
         run: |
+          yarn && yarn build
           DATE=$(date +%Y%m%d%H%M%S)
           publish=(yarn publish --access=public --no-git-tag-version --non-interactive)
           if [[ $GITHUB_REF == refs/tags/v* ]]; then


### PR DESCRIPTION
Fix empty package publication by building it before publishing.

The issue was brought by https://github.com/okp4/ui/pull/282, sorry for that 😢 ..

And thanks @fredericvilcot for having noticing it out so soon 🙏 !