### PR TITLE
fix: remove background images & affiliated urls

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,7 +40,6 @@ export default [
             src: [
               'src/ui/styles/palette.scss',
               'src/ui/styles/themes.scss',
-              'src/ui/styles/urls.scss',
               'src/ui/styles/_exports.module.scss'
             ],
             dest: 'lib/scss'

--- a/src/ui/styles/themes.scss
+++ b/src/ui/styles/themes.scss
@@ -1,5 +1,4 @@
 @import './palette.scss';
-@import './urls.scss';
 
 $themes: (
   light: (
@@ -14,7 +13,6 @@ $themes: (
     primary-background: $color-light-background,
     secondary-background: $color-light-background-variant,
     header-background: $gradient-light-background-header,
-    cosmos-header-background: url($cosmos-light-url) no-repeat #{','} $gradient-light-background-header,
     footer-background: $gradient-light-background-footer,
     footer-block-background: $color-light-background-footer-block,
     success: $color-light-success,
@@ -35,7 +33,6 @@ $themes: (
     primary-background: $color-dark-background,
     secondary-background: $color-dark-background-variant,
     header-background: $gradient-dark-background-header,
-    cosmos-header-background: url($cosmos-dark-url) no-repeat #{','} $gradient-dark-background-header,
     footer-background: $gradient-dark-background-footer,
     footer-block-background: $gradient-dark-background-footer-block,
     success: $color-dark-success,

--- a/src/ui/styles/urls.scss
+++ b/src/ui/styles/urls.scss
@@ -1,2 +1,0 @@
-$cosmos-light-url: '~assets/images/cosmos-clear.png';
-$cosmos-dark-url: '~assets/images/cosmos-dark.png';


### PR DESCRIPTION
This PR reverts https://github.com/okp4/ui/pull/287, https://github.com/okp4/ui/pull/287, https://github.com/okp4/ui/pull/279 and https://github.com/okp4/ui/pull/280