### PR TITLE
Refactor/add input base component

### DIFF
--- a/src/ui/atoms/inputBase/InputBase.tsx
+++ b/src/ui/atoms/inputBase/InputBase.tsx
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/prefer-readonly-parameter-types */
+import React from 'react'
+import type { RefObject } from 'react'
+import classNames from 'classnames'
+import './inputBase.scss'
+
+export type InputBaseProps = Readonly<{
+  /**
+   * Placeholder text.
+   */
+  readonly placeholder?: string
+  /**
+   * Defines the callback called when the input value changes.
+   */
+  readonly onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  /**
+   * The value of the `input` element, required for a controlled component.
+   */
+  readonly value?: string | string[]
+  /*
+   * The default value. Use when the component is not controlled.
+   */
+  readonly defaultValue?: string | string[]
+  /**
+   * Indicates if the input area is disabled.
+   */
+  readonly disabled?: boolean
+  /**
+   * If true, the input is displayed in an error state.
+   */
+  readonly hasError?: boolean
+  /**
+   * Pass a ref to the input element.
+   */
+  readonly inputRef?: RefObject<HTMLInputElement>
+}>
+
+export const InputBase = ({
+  defaultValue,
+  disabled = false,
+  hasError = false,
+  inputRef,
+  onChange,
+  placeholder,
+  value
+}: InputBaseProps): JSX.Element => {
+  const inputClass = classNames(`okp4-input-base`, { error: hasError })
+  return (
+    <input
+      className={inputClass}
+      defaultValue={defaultValue}
+      disabled={disabled}
+      onChange={onChange}
+      placeholder={placeholder}
+      ref={inputRef}
+      value={value}
+    />
+  )
+}

--- a/src/ui/atoms/inputBase/InputBase.tsx
+++ b/src/ui/atoms/inputBase/InputBase.tsx
@@ -5,7 +5,7 @@ import type { RefObject } from 'react'
 import classNames from 'classnames'
 import './inputBase.scss'
 
-export type InputBaseProps = Readonly<{
+export type InputBaseProps = {
   /**
    * Placeholder text.
    */
@@ -34,7 +34,7 @@ export type InputBaseProps = Readonly<{
    * Pass a ref to the input element.
    */
   readonly inputRef?: RefObject<HTMLInputElement>
-}>
+}
 
 export const InputBase = ({
   defaultValue,

--- a/src/ui/atoms/inputBase/InputBase.tsx
+++ b/src/ui/atoms/inputBase/InputBase.tsx
@@ -44,7 +44,7 @@ export const InputBase = ({
   placeholder,
   value
 }: InputBaseProps): JSX.Element => {
-  const inputClass = classNames(`okp4-input-base`, { error: hasError })
+  const inputClass = classNames(`okp4-input-base-main`, { error: hasError })
   return (
     <input
       className={inputClass}

--- a/src/ui/atoms/inputBase/InputBase.tsx
+++ b/src/ui/atoms/inputBase/InputBase.tsx
@@ -1,3 +1,4 @@
+// This rule is deactivated because we can not add readonly on the entire ChangeEvent
 /* eslint-disable @typescript-eslint/prefer-readonly-parameter-types */
 import React from 'react'
 import type { RefObject } from 'react'
@@ -17,7 +18,7 @@ export type InputBaseProps = Readonly<{
    * The value of the `input` element, required for a controlled component.
    */
   readonly value?: string | string[]
-  /*
+  /**
    * The default value. Use when the component is not controlled.
    */
   readonly defaultValue?: string | string[]
@@ -45,6 +46,7 @@ export const InputBase = ({
   value
 }: InputBaseProps): JSX.Element => {
   const inputClass = classNames(`okp4-input-base-main`, { error: hasError })
+
   return (
     <input
       className={inputClass}

--- a/src/ui/atoms/inputBase/inputBase.scss
+++ b/src/ui/atoms/inputBase/inputBase.scss
@@ -1,0 +1,27 @@
+@import 'src/ui/styles/themes.scss';
+
+.okp4-input-base {
+  @include with-theme() {
+    font-family: 'Gotham light', sans-serif;
+    text-align: left;
+    border: 0;
+    padding: 18px;
+    color: themed('text');
+    background: themed('field');
+    font-size: 20px;
+
+    &::placeholder {
+      color: themed('text');
+      opacity: 0.6;
+    }
+
+    &.error {
+      color: themed('error');
+      border: 1px solid themed('error');
+    }
+
+    &:focus {
+      outline: none;
+    }
+  }
+}

--- a/src/ui/atoms/inputBase/inputBase.scss
+++ b/src/ui/atoms/inputBase/inputBase.scss
@@ -1,6 +1,6 @@
 @import 'src/ui/styles/themes.scss';
 
-.okp4-input-base {
+.okp4-input-base-main {
   @include with-theme() {
     font-family: 'Gotham light', sans-serif;
     text-align: left;

--- a/src/ui/atoms/textField/TextField.tsx
+++ b/src/ui/atoms/textField/TextField.tsx
@@ -6,22 +6,21 @@ import { InputBase } from '../inputBase/InputBase'
 import type { InputBaseProps } from '../inputBase/InputBase'
 import './textField.scss'
 
-export type TextFieldProps = InputBaseProps &
-  Readonly<{
-    /**
-     * The size of the input field.
-     * It will be automatically adjusted responsively to the screen size.
-     */
-    readonly size?: 'x-large' | 'large' | 'medium' | 'small' | 'x-small'
-    /**
-     * Displays a message to the user below the input area.
-     */
-    readonly helperText?: string
-    /**
-     * If true, the TextField will take 100% of its parent's size
-     */
-    readonly fullWidth?: boolean
-  }>
+export type TextFieldProps = InputBaseProps & {
+  /**
+   * The size of the input field.
+   * It will be automatically adjusted responsively to the screen size.
+   */
+  readonly size?: 'x-large' | 'large' | 'medium' | 'small' | 'x-small'
+  /**
+   * Displays a message to the user below the input area.
+   */
+  readonly helperText?: string
+  /**
+   * If true, the TextField will take 100% of its parent's size
+   */
+  readonly fullWidth?: boolean
+}
 
 export const TextField: React.FC<TextFieldProps> = ({
   size = 'medium',

--- a/src/ui/atoms/textField/TextField.tsx
+++ b/src/ui/atoms/textField/TextField.tsx
@@ -1,54 +1,27 @@
 /* eslint-disable @typescript-eslint/prefer-readonly-parameter-types */
 import classNames from 'classnames'
-import type { RefObject } from 'react'
 import React from 'react'
 import { Typography } from '../typography/Typography'
 import { InputBase } from '../inputBase/InputBase'
+import type { InputBaseProps } from '../inputBase/InputBase'
 import './textField.scss'
 
-export type TextFieldProps = Readonly<{
-  /**
-   * The size of the input field.
-   * It will be automatically adjusted responsively to the screen size.
-   */
-  readonly size?: 'x-large' | 'large' | 'medium' | 'small' | 'x-small'
-  /**
-   * Placeholder text.
-   */
-  readonly placeholder?: string
-  /**
-   * Defines the callback called when the input value changes.
-   */
-  readonly onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
-  /**
-   * The value of the `input` element, required for a controlled component.
-   */
-  readonly value?: string
-  /**
-   * The default value. Use when the component is not controlled.
-   */
-  readonly defaultValue?: string
-  /**
-   * Indicates if the input area is disabled.
-   */
-  readonly disabled?: boolean
-  /**
-   * If true, the TextField is displayed in an error state.
-   */
-  readonly hasError?: boolean
-  /**
-   * Displays a message to the user below the input area.
-   */
-  readonly helperText?: string
-  /**
-   * Pass a ref to the input element.
-   */
-  readonly inputRef?: RefObject<HTMLInputElement>
-  /**
-   * If true, the TextField will take 100% of its parent's size
-   */
-  readonly fullWidth?: boolean
-}>
+export type TextFieldProps = InputBaseProps &
+  Readonly<{
+    /**
+     * The size of the input field.
+     * It will be automatically adjusted responsively to the screen size.
+     */
+    readonly size?: 'x-large' | 'large' | 'medium' | 'small' | 'x-small'
+    /**
+     * Displays a message to the user below the input area.
+     */
+    readonly helperText?: string
+    /**
+     * If true, the TextField will take 100% of its parent's size
+     */
+    readonly fullWidth?: boolean
+  }>
 
 export const TextField: React.FC<TextFieldProps> = ({
   size = 'medium',

--- a/src/ui/atoms/textField/TextField.tsx
+++ b/src/ui/atoms/textField/TextField.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import type { RefObject } from 'react'
 import React from 'react'
 import { Typography } from '../typography/Typography'
+import { InputBase } from '../inputBase/InputBase'
 import './textField.scss'
 
 export type TextFieldProps = Readonly<{
@@ -61,32 +62,29 @@ export const TextField: React.FC<TextFieldProps> = ({
   inputRef,
   fullWidth = false
 }: TextFieldProps): JSX.Element => {
-  const inputClass = classNames(`okp4-text-field-core `, { error: hasError })
   const containerClass = classNames(`okp4-text-field-main ${size}`, { 'full-width': fullWidth })
 
   return (
     <div className={containerClass}>
-      <input
-        className={inputClass}
+      <InputBase
         defaultValue={defaultValue}
         disabled={disabled}
+        hasError={hasError}
+        inputRef={inputRef}
         onChange={onChange}
         placeholder={placeholder}
-        ref={inputRef}
         value={value}
       />
       {helperText && (
-        <div>
-          <Typography
-            as="div"
-            color={hasError ? 'error' : 'info'}
-            fontSize="x-small"
-            fontWeight={'bold'}
-            noWrap
-          >
-            {helperText}
-          </Typography>
-        </div>
+        <Typography
+          as="div"
+          color={hasError ? 'error' : 'info'}
+          fontSize="x-small"
+          fontWeight="bold"
+          noWrap
+        >
+          {helperText}
+        </Typography>
       )}
     </div>
   )

--- a/src/ui/atoms/textField/textField.scss
+++ b/src/ui/atoms/textField/textField.scss
@@ -1,6 +1,3 @@
-@import 'src/ui/styles/themes.scss';
-@import 'src/ui/styles/main';
-
 $sizes: (
   'x-small': 200px,
   'small': 300px,
@@ -10,43 +7,17 @@ $sizes: (
 );
 
 .okp4-text-field-main {
-  @include with-theme() {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 100%;
 
-    @each $size-key, $size-value in $sizes {
-      &.#{$size-key} {
-        width: $size-value;
+  @each $size-key, $size-value in $sizes {
+    &.#{$size-key} {
+      width: $size-value;
 
-        &.full-width {
-          width: 100%;
-        }
-      }
-    }
-
-    .okp4-text-field-core {
-      font-family: 'Gotham light', sans-serif;
-      text-align: left;
-      border: 0;
-      padding: 18px;
-      color: themed('text');
-      background: themed('field');
-      font-size: 20px;
-
-      &::placeholder {
-        color: themed('text');
-        opacity: 0.6;
-      }
-
-      &.error {
-        color: themed('error');
-        border: 1px solid themed('error');
-      }
-
-      &:focus {
-        outline: none;
+      &.full-width {
+        width: 100%;
       }
     }
   }

--- a/stories/atoms/components/textField/TextField.stories.mdx
+++ b/stories/atoms/components/textField/TextField.stories.mdx
@@ -1,4 +1,5 @@
-import { ArgsTable, Meta, Story, Canvas, Preview, Props } from '@storybook/addon-docs'
+import { useRef, useState } from 'react'
+import { ArgsTable, Meta, Story, Canvas } from '@storybook/addon-docs'
 import { ThemeProvider } from 'ui/atoms/theme/ThemeProvider'
 import { ThemeSwitcher } from 'ui/atoms/theme/ThemeSwitcher'
 import { TextField } from 'ui/atoms/textField/TextField'
@@ -31,13 +32,15 @@ import '../component.scss'
 
 # TextField component
 
+> Allows the user to enter some text into a field.
+
 [![stability-unstable](https://img.shields.io/badge/stability-unstable-yellow.svg)](https://github.com/emersion/stability-badges#unstable)
 
 ## Description
 
-**TextField** is a minimalist text input component that integrates easily with OKP4 design system.
+`TextField` is a minimalist text input component that integrates easily with OKP4 design system.
 
-## Usage
+## Overview
 
 <Story
   name="Usage"
@@ -47,11 +50,16 @@ import '../component.scss'
     },
     inputRef: {
       control: false
+    },
+    value: {
+      control: { type: 'select' },
+      options: ['string', ['array', 'of', 'string']]
     }
   }}
   args={{
     placeholder: "I'm a placeholder!",
-    defaultValue: "I'm set with a default value"
+    defaultValue: "I'm set with a default value",
+    value: undefined
   }}
 >
   {args => (
@@ -139,23 +147,49 @@ In addition, the `helperText` property can be set to display an error message be
   </Story>
 </Canvas>
 
-## Reacting to changes
+## Controlled TextField
 
-The `TextField` component provides an`onChange` property called when the input value changes.
+When the component is controlled, the parent passes a value to the `TextField` which displays it.  
+Parent has its own state in order to control the value which is passed, and it also specify an `onChange` handler property which will be called when user updates the value.  
+In the example below, everytime the input value changes, current state is updated and a log message displays the content of the value.
 
-##### **`MyComponent.tsx`**
+<Canvas isColumn>
+  <Story name="Controlled">
+    {args => {
+      const [value, setValue] = useState('I am controlled: value is passed by my parent')
+      const handleChange = event => {
+        setValue(event.target.value)
+        console.log(`My new value is : ${event.target.value}`)
+      }
+      return (
+        <div style={{ display: 'flex', justifyContent: 'center', maxWidth: '100%' }}>
+          <TextField value={value} onChange={handleChange} fullWidth />
+        </div>
+      )
+    }}
+  </Story>
+</Canvas>
 
-```tsx
-import React from 'react'
-import type { ChangeEvent, FC } from 'react'
-import { TextField } from '@okp4/ui'
+## Uncontrolled TextField
 
-const MyComponent: FC = () => {
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    console.log(event.target.value)
-  }
-  return <TextField onChange={handleChange} />
-}
-```
+The `TextField` component comes with an optional property called `defaultValue`.  
+It can be used when the component in uncontrolled, which implies that no value is passed to `value` or `onChange`.  
+Data is handled by the DOM itself, this is the source of truth.
+If you want to access the value, you can use a ref to get value from the DOM, but it is recommended to interact with values by choosing a controlled component which is more appropriated.
 
-Then, everytime the input value changes, a log message displays the content of the value.
+<Canvas isColumn>
+  <Story name="Uncontrolled">
+    {args => {
+      const textFieldRef = useRef()
+      return (
+        <div style={{ display: 'flex', justifyContent: 'center', maxWidth: '100%' }}>
+          <TextField
+            defaultValue="I am uncontrolled, I just have a default value"
+            fullWidth
+            ref={textFieldRef}
+          />
+        </div>
+      )
+    }}
+  </Story>
+</Canvas>


### PR DESCRIPTION
This PR creates a new basic input `InputBase` in order to share a part of the code and to be able to use it with other components like here the `TextField` or the future `Select`.