### PR TITLE
fix: remove svg files from rollup-plugin-image scope

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -58,7 +58,7 @@ export default {
       verbose: true
     }),
     svgr({ dimensions: false }),
-    image(),
+    image({ exclude: ['src/**/*.svg'] }),
     json(),
     resolve({ preferBuiltins: true, mainFields: ['browser'] }),
     postcss(),


### PR DESCRIPTION
This PR prevents `@rollup/plugin-image` to inline svg files instead of `@svgr/rollup`