### PR TITLE
🪝 Add `useElementSize()` hook for Canvas

### DIFF
--- a/src/hook/useElementSize.ts
+++ b/src/hook/useElementSize.ts
@@ -1,0 +1,36 @@
+import { useEffect, useCallback, useState } from 'react'
+
+export type ElementSize = Readonly<{
+  width: number
+  height: number
+}>
+
+export const useElementSize: <T extends HTMLElement = HTMLDivElement>() => [
+  ElementSize | null,
+  (node: T | null) => void
+] = <T extends HTMLElement = HTMLDivElement>() => {
+  type Opt<U> = U | null
+  type State<U> = [U, (value: U) => void]
+
+  const [ref, setRef]: State<Opt<T>> = useState<Opt<T>>(null)
+  const [size, setSize]: State<Opt<ElementSize>> = useState<Opt<ElementSize>>(null)
+
+  const handleSize = useCallback(() => {
+    if (ref) {
+      setSize({
+        width: ref.offsetWidth,
+        height: ref.offsetHeight
+      })
+    }
+  }, [ref])
+
+  useEffect(() => {
+    window.addEventListener('resize', handleSize)
+
+    handleSize()
+
+    return () => window.removeEventListener('resize', handleSize)
+  }, [handleSize])
+
+  return [size, setRef]
+}

--- a/stories/atoms/components/canvas/Canvas.stories.mdx
+++ b/stories/atoms/components/canvas/Canvas.stories.mdx
@@ -71,7 +71,7 @@ export const SimpleCanvas = args => (
 
 ## Auto resize
 
-Sometimes, you may want to resize the `Canvas` compopnent to fit the element or window that it’s in. To do this, simply bind the `resize` event and, once the event is caught,
+Sometimes, you may want to resize the `Canvas` component to fit the element or window that it’s in. To do this, simply bind the `resize` event and, once the event is caught,
 resize the canvas by setting on the fly its `width` and `height` properties.
 
 The OKP4 design system provides a simple mechanism for this: the hook `useElementSize`. This hook helps you to dynamically retrieve the width and the height of an HTML element.

--- a/stories/atoms/components/canvas/Canvas.stories.mdx
+++ b/stories/atoms/components/canvas/Canvas.stories.mdx
@@ -1,5 +1,6 @@
 import { ArgsTable, Meta, Story, Canvas, Preview, Props } from '@storybook/addon-docs'
 import { Canvas as CanvasComponent } from 'ui/atoms/canvas/Canvas'
+import { useElementSize } from 'hook/useElementSize'
 
 <Meta
   title="Atoms/Canvas"
@@ -44,7 +45,7 @@ export const draw = (canvas, deltaCount) => {
   ctx.fill()
 }
 
-export const CanvasStory = args => (
+export const SimpleCanvas = args => (
   <div style={{ textAlign: 'center', padding: '10px 0 10px' }}>
     <CanvasComponent {...args} />
   </div>
@@ -60,10 +61,83 @@ export const CanvasStory = args => (
       height: 200
     }}
   >
-    {CanvasStory.bind({})}
+    {SimpleCanvas.bind({})}
   </Story>
 </Canvas>
 
 ### Properties
 
 <ArgsTable story="Overview" />
+
+## Auto resize
+
+Sometimes, you may want to resize the `Canvas` compopnent to fit the element or window that it’s in. To do this, simply bind the `resize` event and, once the event is caught,
+resize the canvas by setting on the fly its `width` and `height` properties.
+
+The OKP4 design system provides a simple mechanism for this: the hook `useElementSize`. This hook helps you to dynamically retrieve the width and the height of an HTML element.
+
+For instance:
+
+```tsx
+const draw = (canvas, deltaCount) => { ... }
+const [ size, divRef ] = useElementSize()
+
+return (
+<div style={{ textAlign: 'center', padding: '10px 0 10px' }} ref={divRef}>
+  <CanvasComponent 
+    width={size?.width} 
+    height={size?.height} 
+    onRender={draw} />
+</div>)
+```
+
+export let x = -1
+export let y = -1
+export let dx = 2
+export const drawSize = (canvas, deltaCount) => {
+  const ctx = canvas.getContext('2d')
+  const text = `Size: ${canvas.width} / ${canvas.height}`
+  const metrics = ctx.measureText(text)
+  if(x == -1) {
+    x = (canvas.width - metrics.width) / 2 
+  }
+  if(y == -1) {
+    y = canvas.height / 2
+  }
+  ctx.clearRect(0, 0, canvas.width, canvas.height)
+  ctx.fillStyle = "#0f224a"
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+  ctx.fillStyle = "#ced2d9"
+  ctx.font = "25px sans-serif"
+  ctx.fillText(text, x, y)
+  ctx.fill()
+  if(x + metrics.width > canvas.width) {
+    x = canvas.width - metrics.width
+    dx = -dx
+  }
+  if(x <= 0) {
+    x = 1
+    dx = -dx
+  }
+  x += dx;
+}
+
+export const ResizableCanvas = args => {
+  const [ size, divRef ] = useElementSize()
+  return (
+    <div style={{ textAlign: 'center', padding: '10px 0 10px' }} ref={divRef}>
+      <CanvasComponent width={size?.width} height={200} {...args} />
+    </div>)
+}
+
+<Canvas>
+  <Story
+    name="Auto resize"
+    args={{
+      onRender: drawSize,
+      disableScrolling: false
+    }}
+  >
+    {ResizableCanvas.bind({})}
+  </Story>
+</Canvas>


### PR DESCRIPTION
This PR addresses the feature request #353. It adds the `useElementSize()` hook which can be used to track the resizing of an element (typically a parent) in order to resize components on the fly.

This JS oriented approach is needed mainly for the `canvas` component for which there is a need to set a value for the `width` and `height` properties. The Story describing the `canvas` has been updated to explain the use of this hook in this case.