### PR TITLE
ci(follow): don't make anik follow dependabot

### DIFF
--- a/.github/workflows/follow-contributor.yml
+++ b/.github/workflows/follow-contributor.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   follow-user:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-20.04
     steps:
       - name: Follow user


### PR DESCRIPTION
Self explanatory.
I guess, later on, the action will be modified not to fail if it's impossible to follow the contributor.