### PR TITLE
docs(story): fix source code display in mdx

### DIFF
--- a/stories/organisms/components/faucet/Faucet.stories.mdx
+++ b/stories/organisms/components/faucet/Faucet.stories.mdx
@@ -89,7 +89,7 @@ The following `config.json` file is a configuration example for connecting to th
 
 **`config.json`**
 
-<Source code={JSON.stringify(env, null, 2)} language='json'/>
+<Source code={JSON.stringify(env.default, null, 2)} language='json'/>
 
 ### 2. Instanciate redux stores to init the component
 


### PR DESCRIPTION
The stringification of the imported `env.json` makes a default node appear in the block code of the mdx, which duplicates the content. The fix corrects this to reflect the exact content of the imported file.