### PR TITLE
refactor: rename StateHook type to UseState

### DIFF
--- a/src/superTypes.ts
+++ b/src/superTypes.ts
@@ -23,6 +23,6 @@ export type JSONValue = string | number | boolean | { [x: string]: JSONValue } |
 
 export type Pair<U, V> = [U, V]
 
-export type StateHook<U> = [U, (value: U) => void]
+export type UseState<U> = [U, (value: U) => void]
 
-export type Callback<U,V> = (value: U) => V
+export type Callback<U, V> = (value: U) => V

--- a/src/ui/atoms/babylonEngine/BabylonEngine.tsx
+++ b/src/ui/atoms/babylonEngine/BabylonEngine.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import type { EngineOptions } from '@babylonjs/core'
 import { Engine } from '@babylonjs/core'
 import { Canvas } from 'ui/atoms/canvas/Canvas'
-import type { Callback, DeepReadonly, StateHook } from 'superTypes'
+import type { Callback, DeepReadonly, UseState } from 'superTypes'
 
 export type EngineCreatedCallback<STATE> = Callback<Engine, STATE>
 export type RenderCallback<STATE> = Callback<STATE, STATE>
@@ -68,9 +68,9 @@ export const BabylonEngine = <STATE,>({
   onRender,
   ...props
 }: DeepReadonly<BabylonEngineProps<STATE>>): JSX.Element => {
-  const [canvas, setCanvas]: StateHook<HTMLCanvasElement | null> =
+  const [canvas, setCanvas]: UseState<HTMLCanvasElement | null> =
     useState<HTMLCanvasElement | null>(null)
-  const [engine, setEngine]: StateHook<Engine | null> = useState<Engine | null>(null)
+  const [engine, setEngine]: UseState<Engine | null> = useState<Engine | null>(null)
   const stateRef = useRef<STATE | null>(null)
 
   useEffect(() => {


### PR DESCRIPTION
This PR is about renaming the type `StateHook` to `UseState` : 
`export type UseState<U> = [U, (value: U) => void]` 