### PR TITLE
Feat/faucet subscription

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
 end_of_line = lf

--- a/codegen.yml
+++ b/codegen.yml
@@ -11,6 +11,7 @@ generates:
         Address: string
         Long: BigUint64Array
         UInt64: BigUint64Array
+        Void: string
       immutableTypes: true
       strictScalars: true
       useTypeImports: true

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "bech32-buffer": "^0.2.0",
     "classnames": "^2.3.1",
     "graphql": "^16.5.0",
+    "graphql-ws": "^5.10.0",
     "i18next": "^21.6.16",
     "i18next-browser-languagedetector": "^6.1.4",
     "immutable": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@graphql-codegen/typescript": "^2.4.11",
     "@graphql-codegen/typescript-operations": "^2.4.0",
     "@keplr-wallet/types": "^0.10.4",
-    "@okp4/cosmos-faucet-schema": "^1.0.0",
+    "@okp4/cosmos-faucet-schema": "^1.1.0",
     "@okp4/eslint-config": "^1.1.0",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-graphql": "^1.1.0",

--- a/src/adapters/faucet/secondary/graphql/HTTPFaucetGateway.spec.ts
+++ b/src/adapters/faucet/secondary/graphql/HTTPFaucetGateway.spec.ts
@@ -1,15 +1,11 @@
-import {
-  OperationContext,
-  OperationResult,
-  TypedDocumentNode
-} from '@urql/core'
+import { AnyVariables, OperationContext, OperationResult, TypedDocumentNode } from '@urql/core'
 import * as client from './client'
 import { FaucetGatewayError, UnspecifiedError } from 'domain/faucet/entity/error'
 import { SEND_TOKENS_SUBSCRIPTION } from './documents/sendTokens'
-import { MSendTokensSubscription, MSendTokensSubscriptionVariables } from './generated/types'
+import { SSendTokensSubscription, SSendTokensSubscriptionVariables } from './generated/types'
 import { HTTPFaucetGateway } from './HTTPFaucetGateway'
 import { DocumentNode } from 'graphql'
-import { fromValue, Source } from "wonka";
+import { fromValue, Source } from 'wonka'
 
 jest.mock('./client', () => ({
   __esModule: true,
@@ -31,10 +27,10 @@ const fakeOperation = {
   query: SEND_TOKENS_SUBSCRIPTION
 }
 let fakeUrqlSubscriptionFn: jest.SpyInstance<
-  Source<OperationResult<unknown, object>>,
+  Source<OperationResult<unknown, AnyVariables>>,
   [
-    query: string | DocumentNode | TypedDocumentNode<unknown, object>,
-    variables?: object | undefined,
+    query: string | DocumentNode | TypedDocumentNode<unknown, AnyVariables>,
+    variables?: AnyVariables | undefined,
     context?: Partial<OperationContext> | undefined
   ]
 >
@@ -55,20 +51,21 @@ describe('Given a HTTPFaucetGateway instance', () => {
         beforeEach(() => {
           fakeUrqlSubscriptionFn = jest.spyOn(fakeUrqlClient, 'subscription').mockImplementation(
             (): Source<
-              OperationResult<MSendTokensSubscription, MSendTokensSubscriptionVariables>
+              OperationResult<SSendTokensSubscription, SSendTokensSubscriptionVariables>
               // @ts-ignore
-            > => fromValue({
-              operation: fakeOperation,
-              data: expectedData,
-              ...(hasError && {
-                error: {
-                  name: 'test-error',
-                  message: 'test-message',
-                  graphQLErrors: [],
-                  networkError: new Error()
-                }
+            > =>
+              fromValue({
+                operation: fakeOperation,
+                data: expectedData,
+                ...(hasError && {
+                  error: {
+                    name: 'test-error',
+                    message: 'test-message',
+                    graphQLErrors: [],
+                    networkError: new Error()
+                  }
+                })
               })
-            })
           )
         })
 

--- a/src/adapters/faucet/secondary/graphql/HTTPFaucetGateway.ts
+++ b/src/adapters/faucet/secondary/graphql/HTTPFaucetGateway.ts
@@ -27,7 +27,7 @@ export class HTTPFaucetGateway implements FaucetPort {
       throw new FaucetGatewayError(result.error.message)
     }
 
-    if (!result.data) {
+    if (!result.data || result.data.send.code !== 0) {
       throw new UnspecifiedError('Oooops... An unspecified error occured while requesting funds..')
     }
 

--- a/src/adapters/faucet/secondary/graphql/HTTPFaucetGateway.ts
+++ b/src/adapters/faucet/secondary/graphql/HTTPFaucetGateway.ts
@@ -1,7 +1,7 @@
 import client from './client'
-import {pipe, toPromise} from 'wonka';
+import { pipe, toPromise } from 'wonka'
 import { SEND_TOKENS_SUBSCRIPTION } from './documents/sendTokens'
-import type { MSendTokensSubscription, MSendTokensSubscriptionVariables } from './generated/types'
+import type { SSendTokensSubscription, SSendTokensSubscriptionVariables } from './generated/types'
 import { FaucetGatewayError, UnspecifiedError } from 'domain/faucet/entity/error'
 import type { FaucetPort } from 'domain/faucet/port/faucetPort'
 
@@ -13,15 +13,17 @@ export class HTTPFaucetGateway implements FaucetPort {
   }
 
   public requestFunds = async (address: string): Promise<string> => {
-      const result = await pipe(
-          client(this.faucetUrl)
-              .subscription<MSendTokensSubscription, MSendTokensSubscriptionVariables>(SEND_TOKENS_SUBSCRIPTION, {
-                  input: {
-                      toAddress: address
-                  }
-              }),
-          toPromise
-      )
+    const result = await pipe(
+      client(this.faucetUrl).subscription<
+        SSendTokensSubscription,
+        SSendTokensSubscriptionVariables
+      >(SEND_TOKENS_SUBSCRIPTION, {
+        input: {
+          toAddress: address
+        }
+      }),
+      toPromise
+    )
 
     if (result.error) {
       throw new FaucetGatewayError(result.error.message)

--- a/src/adapters/faucet/secondary/graphql/client.spec.ts
+++ b/src/adapters/faucet/secondary/graphql/client.spec.ts
@@ -1,0 +1,20 @@
+import { makeWSURL } from './client'
+
+describe.each`
+  desc                                  | url                                             | expected_ws_url
+  ${"an url with unknown protocol"}     | ${"wtf://w.tf/graphql"}                         | ${"ws://w.tf/graphql"}
+  ${"a classic http url"}               | ${"http://faucet.testnet.okp4.network/graphql"} | ${"ws://faucet.testnet.okp4.network/graphql"}
+  ${"an http url with a specific port"} | ${"http://localhost:8080/graphql"}              | ${"ws://localhost:8080/graphql"}
+  ${"an https url"}                     | ${"https://give.me.tokens/free/graphql"}        | ${"wss://give.me.tokens/free/graphql"}
+`(
+  `Given <$desc>.`,
+  ({desc, url, expected_ws_url}) => {
+    describe("When mapping to a websocket url.", () => {
+      const result = makeWSURL(url)
+
+      test("Then the returned url shall be properly mapped.", () => {
+        expect(result).toBe(expected_ws_url)
+      })
+    })
+  }
+)

--- a/src/adapters/faucet/secondary/graphql/client.spec.ts
+++ b/src/adapters/faucet/secondary/graphql/client.spec.ts
@@ -2,19 +2,16 @@ import { makeWSURL } from './client'
 
 describe.each`
   desc                                  | url                                             | expected_ws_url
-  ${"an url with unknown protocol"}     | ${"wtf://w.tf/graphql"}                         | ${"ws://w.tf/graphql"}
-  ${"a classic http url"}               | ${"http://faucet.testnet.okp4.network/graphql"} | ${"ws://faucet.testnet.okp4.network/graphql"}
-  ${"an http url with a specific port"} | ${"http://localhost:8080/graphql"}              | ${"ws://localhost:8080/graphql"}
-  ${"an https url"}                     | ${"https://give.me.tokens/free/graphql"}        | ${"wss://give.me.tokens/free/graphql"}
-`(
-  `Given <$desc>.`,
-  ({desc, url, expected_ws_url}) => {
-    describe("When mapping to a websocket url.", () => {
-      const result = makeWSURL(url)
+  ${'an url with unknown protocol'}     | ${'wtf://w.tf/graphql'}                         | ${'ws://w.tf/graphql'}
+  ${'a classic http url'}               | ${'http://faucet.testnet.okp4.network/graphql'} | ${'ws://faucet.testnet.okp4.network/graphql'}
+  ${'an http url with a specific port'} | ${'http://localhost:8080/graphql'}              | ${'ws://localhost:8080/graphql'}
+  ${'an https url'}                     | ${'https://give.me.tokens/free/graphql'}        | ${'wss://give.me.tokens/free/graphql'}
+`(`Given <$desc>.`, ({ desc, url, expected_ws_url }) => {
+  describe('When mapping to a websocket url.', () => {
+    const result = makeWSURL(url)
 
-      test("Then the returned url shall be properly mapped.", () => {
-        expect(result).toBe(expected_ws_url)
-      })
+    test('Then the returned url shall be properly mapped.', () => {
+      expect(result).toBe(expected_ws_url)
     })
-  }
-)
+  })
+})

--- a/src/adapters/faucet/secondary/graphql/client.ts
+++ b/src/adapters/faucet/secondary/graphql/client.ts
@@ -1,38 +1,36 @@
-import {createClient, defaultExchanges, subscriptionExchange} from '@urql/core'
+import { createClient, defaultExchanges, subscriptionExchange } from '@urql/core'
 import type { Client, ExecutionResult } from '@urql/core'
-import { createClient as createWSClient } from 'graphql-ws';
-import type {ObserverLike, SubscriptionOperation} from "@urql/core/dist/types/exchanges/subscription";
-import type {DeepReadonly} from "superTypes";
+import { createClient as createWSClient } from 'graphql-ws'
+import type {
+  ObserverLike,
+  SubscriptionOperation
+} from '@urql/core/dist/types/exchanges/subscription'
+import type { DeepReadonly } from 'superTypes'
 
-const urlReg = new RegExp("^(?<scheme>[a-z][a-z0-9+\\-.]*)://(?<target>.*)$")
+const urlReg = new RegExp('^(?<scheme>[a-z][a-z0-9+\\-.]*)://(?<target>.*)$')
 
 export const makeWSURL = (rawURL: string): string => {
-    const match = urlReg.exec(rawURL)
-    const wsProtocol = (): string => {
-        if (match?.groups?.scheme === "https") {
-            return "wss"
-        }
-        return "ws"
-    }
-    
-    return `${wsProtocol()}://${match?.groups?.target}`
+  const match = urlReg.exec(rawURL)
+  const wsProtocol = (): string => (match?.groups?.scheme === 'https' ? 'wss' : 'ws')
+  return `${wsProtocol()}://${match?.groups?.target}`
 }
 
-const client = (url: string): Client => createClient({
+const client = (url: string): Client =>
+  createClient({
     url,
     requestPolicy: 'network-only',
     exchanges: [
-        ...defaultExchanges,
-        subscriptionExchange({
-            forwardSubscription: (operation: DeepReadonly<SubscriptionOperation>) => ({
-                subscribe: (sink: DeepReadonly<ObserverLike<ExecutionResult>>) => ({
-                    unsubscribe: createWSClient({
-                        url: makeWSURL(url)
-                    }).subscribe(operation, sink),
-                }),
-            }),
-        }),
-    ],
-})
+      ...defaultExchanges,
+      subscriptionExchange({
+        forwardSubscription: (operation: DeepReadonly<SubscriptionOperation>) => ({
+          subscribe: (sink: DeepReadonly<ObserverLike<ExecutionResult>>) => ({
+            unsubscribe: createWSClient({
+              url: makeWSURL(url)
+            }).subscribe(operation, sink)
+          })
+        })
+      })
+    ]
+  })
 
 export default client

--- a/src/adapters/faucet/secondary/graphql/client.ts
+++ b/src/adapters/faucet/secondary/graphql/client.ts
@@ -1,6 +1,38 @@
-import { createClient } from '@urql/core'
-import type { Client } from '@urql/core'
+import {createClient, defaultExchanges, subscriptionExchange} from '@urql/core'
+import type { Client, ExecutionResult } from '@urql/core'
+import { createClient as createWSClient } from 'graphql-ws';
+import type {ObserverLike, SubscriptionOperation} from "@urql/core/dist/types/exchanges/subscription";
+import type {DeepReadonly} from "superTypes";
 
-const client = (url: string): Client => createClient({ url, requestPolicy: 'network-only' })
+const urlReg = new RegExp("^(?<scheme>[a-z][a-z0-9+\\-.]*)://(?<target>.*)$")
+
+export const makeWSURL = (rawURL: string): string => {
+    const match = urlReg.exec(rawURL)
+    const wsProtocol = (): string => {
+        if (match?.groups?.scheme === "https") {
+            return "wss"
+        }
+        return "ws"
+    }
+    
+    return `${wsProtocol()}://${match?.groups?.target}`
+}
+
+const client = (url: string): Client => createClient({
+    url,
+    requestPolicy: 'network-only',
+    exchanges: [
+        ...defaultExchanges,
+        subscriptionExchange({
+            forwardSubscription: (operation: DeepReadonly<SubscriptionOperation>) => ({
+                subscribe: (sink: DeepReadonly<ObserverLike<ExecutionResult>>) => ({
+                    unsubscribe: createWSClient({
+                        url: makeWSURL(url)
+                    }).subscribe(operation, sink),
+                }),
+            }),
+        }),
+    ],
+})
 
 export default client

--- a/src/adapters/faucet/secondary/graphql/documents/sendTokens.ts
+++ b/src/adapters/faucet/secondary/graphql/documents/sendTokens.ts
@@ -1,7 +1,7 @@
 import { gql } from '@urql/core'
 
 export const SEND_TOKENS_SUBSCRIPTION = gql`
-  subscription MSendTokens($input: SendInput!) {
+  subscription SSendTokens($input: SendInput!) {
     send(input: $input) {
       hash
       code

--- a/src/adapters/faucet/secondary/graphql/documents/sendTokens.ts
+++ b/src/adapters/faucet/secondary/graphql/documents/sendTokens.ts
@@ -1,7 +1,7 @@
 import { gql } from '@urql/core'
 
-export const SEND_TOKENS_MUTATION = gql`
-  mutation MSendTokens($input: SendInput!) {
+export const SEND_TOKENS_SUBSCRIPTION = gql`
+  subscription MSendTokens($input: SendInput!) {
     send(input: $input) {
       hash
     }

--- a/src/adapters/faucet/secondary/graphql/documents/sendTokens.ts
+++ b/src/adapters/faucet/secondary/graphql/documents/sendTokens.ts
@@ -4,6 +4,7 @@ export const SEND_TOKENS_SUBSCRIPTION = gql`
   subscription MSendTokens($input: SendInput!) {
     send(input: $input) {
       hash
+      code
     }
   }
 `

--- a/src/adapters/faucet/secondary/graphql/generated/types.ts
+++ b/src/adapters/faucet/secondary/graphql/generated/types.ts
@@ -114,9 +114,9 @@ export type TxResponse = {
   readonly rawLog?: Maybe<Scalars['String']>;
 };
 
-export type MSendTokensSubscriptionVariables = Exact<{
+export type SSendTokensSubscriptionVariables = Exact<{
   input: SendInput;
 }>;
 
 
-export type MSendTokensSubscription = { readonly __typename?: 'Subscription', readonly send: { readonly __typename?: 'TxResponse', readonly hash: string, readonly code: number } };
+export type SSendTokensSubscription = { readonly __typename?: 'Subscription', readonly send: { readonly __typename?: 'TxResponse', readonly hash: string, readonly code: number } };

--- a/src/adapters/faucet/secondary/graphql/generated/types.ts
+++ b/src/adapters/faucet/secondary/graphql/generated/types.ts
@@ -119,4 +119,4 @@ export type MSendTokensSubscriptionVariables = Exact<{
 }>;
 
 
-export type MSendTokensSubscription = { readonly __typename?: 'Subscription', readonly send: { readonly __typename?: 'TxResponse', readonly hash: string } };
+export type MSendTokensSubscription = { readonly __typename?: 'Subscription', readonly send: { readonly __typename?: 'TxResponse', readonly hash: string, readonly code: number } };

--- a/src/adapters/faucet/secondary/graphql/generated/types.ts
+++ b/src/adapters/faucet/secondary/graphql/generated/types.ts
@@ -19,6 +19,8 @@ export type Scalars = {
   Long: BigUint64Array;
   /** An unsigned 64-bit integer */
   UInt64: BigUint64Array;
+  /** Represent a void return type, representing no value */
+  Void: string;
 };
 
 /** Represent the actual server configuration */
@@ -43,8 +45,14 @@ export type Configuration = {
 /** List of all mutations */
 export type Mutation = {
   readonly __typename?: 'Mutation';
-  /** Send the configured amount of token to the given address. */
-  readonly send: TxResponse;
+  /**
+   * Send the configured amount of token to the given address, returning nothing as the transaction is made
+   * asynchronously. A successful invocation means that the send operation is queued and will be processed, but it'll
+   * does not necessary lead to a successful transaction.
+   *
+   * For clients needing information on the underlying transaction state, consider using the `send` subscription.
+   */
+  readonly send?: Maybe<Scalars['Void']>;
 };
 
 
@@ -68,6 +76,26 @@ export type SendInput = {
   readonly toAddress: Scalars['Address'];
 };
 
+/** List of all subscriptions */
+export type Subscription = {
+  readonly __typename?: 'Subscription';
+  /**
+   * Send the configured amount of token to the given address.
+   *
+   * By opening the subscription the send message is added to a queue, once the transaction is successfully submitted
+   * with all the queued messages it'll return the corresponding before closing the stream. A successful submission does
+   * not mean it has been successfully written in a block, it is the client's responsibility to make additional checks
+   * through the transaction's code and hash.
+   */
+  readonly send: TxResponse;
+};
+
+
+/** List of all subscriptions */
+export type SubscriptionSendArgs = {
+  input: SendInput;
+};
+
 /** Represent a transaction response */
 export type TxResponse = {
   readonly __typename?: 'TxResponse';
@@ -86,9 +114,9 @@ export type TxResponse = {
   readonly rawLog?: Maybe<Scalars['String']>;
 };
 
-export type MSendTokensMutationVariables = Exact<{
+export type MSendTokensSubscriptionVariables = Exact<{
   input: SendInput;
 }>;
 
 
-export type MSendTokensMutation = { readonly __typename?: 'Mutation', readonly send: { readonly __typename?: 'TxResponse', readonly hash: string } };
+export type MSendTokensSubscription = { readonly __typename?: 'Subscription', readonly send: { readonly __typename?: 'TxResponse', readonly hash: string } };

--- a/src/ui/organisms/faucet/Faucet.tsx
+++ b/src/ui/organisms/faucet/Faucet.tsx
@@ -19,6 +19,7 @@ import { Button } from 'ui/atoms/button/Button'
 import { TextField } from 'ui/atoms/textField/TextField'
 import { Toast } from 'ui/atoms/toast/Toast'
 import { Typography } from 'ui/atoms/typography/Typography'
+import { ProgressBar } from 'ui/atoms/progressBar/ProgressBar'
 import type { DeepReadonly } from 'superTypes'
 import './i18n/index'
 import './faucet.scss'
@@ -41,6 +42,9 @@ export const Faucet: React.FC<FaucetProps> = ({ chainId }: FaucetProps) => {
   const errorMessage = useErrorSelector(unseenErrorMessage)
   const transactionSuccessId = useTaskSelector((state: DeepReadonly<TaskAppState>) =>
     getDisplayedTaskIdByTypeAndStatus(state, faucetTaskType, 'success')
+  )
+  const transactionLoading = useTaskSelector((state: DeepReadonly<TaskAppState>) =>
+      getDisplayedTaskIdByTypeAndStatus(state, faucetTaskType, 'processing')
   )
 
   const acknowledgeFaucetError = useCallback(() => {
@@ -124,6 +128,9 @@ export const Faucet: React.FC<FaucetProps> = ({ chainId }: FaucetProps) => {
             />
           </div>
         </div>
+          <div className="okp4-faucet-content-info-main">
+              {transactionLoading && (<ProgressBar/>)}
+          </div>
         <div className="okp4-faucet-content-info-main">
           <div>
             <Typography color="text" fontSize="x-small" fontWeight="bold">

--- a/src/ui/organisms/faucet/Faucet.tsx
+++ b/src/ui/organisms/faucet/Faucet.tsx
@@ -104,6 +104,7 @@ export const Faucet: React.FC<FaucetProps> = ({ chainId }: FaucetProps) => {
             </Typography>
             <img alt="Keplr logo" src={keplrImage} />
             <Button
+              disabled={transactionLoading !== undefined}
               label={t('faucet:faucet.sendMeToken')}
               onClick={handleRequestWithWallet}
               size="large"
@@ -121,6 +122,7 @@ export const Faucet: React.FC<FaucetProps> = ({ chainId }: FaucetProps) => {
               value={address}
             />
             <Button
+              disabled={transactionLoading !== undefined}
               label={t('faucet:faucet.sendMeToken')}
               onClick={handleRequestWithAddress}
               size="large"

--- a/src/ui/organisms/faucet/faucet.scss
+++ b/src/ui/organisms/faucet/faucet.scss
@@ -1,4 +1,5 @@
 @import 'src/ui/styles/themes';
+@import 'src/ui/styles/animations.scss';
 
 .okp4-faucet-main {
   @include with-theme() {
@@ -67,6 +68,17 @@
 
       > img {
         width: 55px;
+      }
+
+      .okp4-faucet-loader {
+        width: 40px;
+        height: 40px;
+        border: 4px solid themed('text');
+        border-bottom-color: transparent;
+        border-radius: 50%;
+        display: inline-block;
+        box-sizing: border-box;
+        animation: rotation 1s linear infinite;
       }
 
       .okp4-input-base-container {

--- a/src/ui/styles/animations.scss
+++ b/src/ui/styles/animations.scss
@@ -44,6 +44,7 @@
   0% {
     transform: rotate(0deg);
   }
+
   100% {
     transform: rotate(360deg);
   }

--- a/src/ui/styles/animations.scss
+++ b/src/ui/styles/animations.scss
@@ -39,3 +39,12 @@
     }
   }
 }
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2645,10 +2645,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@okp4/cosmos-faucet-schema@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@okp4/cosmos-faucet-schema/-/cosmos-faucet-schema-1.0.0.tgz#00769d2198e92e27091b71c89bcb910b4048f0c3"
-  integrity sha512-UsJLCo8UAdoOkcWs6xtdjBGE6BqBvBWzxK21epaWrns0M87xmgEgkyKsD0TtjA4HtcoeJz4eQXo76kCzoo1PuA==
+"@okp4/cosmos-faucet-schema@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@okp4/cosmos-faucet-schema/-/cosmos-faucet-schema-1.1.0.tgz#aa1928a518c6824081b8e55ffab6185c1e212a98"
+  integrity sha512-vV0RLUmTzU6h4ZASKYfUihyDGAsA0IqSCSoXpvStNRR21bnenw8yB5Z1vifKekEqmYhwhUA08TOIc26n6qZgTA==
 
 "@okp4/eslint-config@^1.1.0":
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9285,6 +9285,11 @@ graphql-tag@^2.11.0, graphql-tag@^2.2.2:
   dependencies:
     tslib "^2.1.0"
 
+graphql-ws@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.10.0.tgz#3fb47a4e809e0d2e7c197f1bca754fa9f31b940e"
+  integrity sha512-ewbPzHQdRZgNCPDH9Yr6xccSeZfk3fmpO/AGGGg4KkM5gc6oAOJQ10Oui1EqprhVOyRbOll9bw2qAkOiOwfTag==
+
 graphql-ws@^5.4.1:
   version "5.8.2"
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.8.2.tgz#800184b1addb20b3010dc06cb70877703a5fff20"


### PR DESCRIPTION
In response to GraphQL API changes on the https://github.com/okp4/cosmos-faucet/pull/79 backend implementation, the client side is adjusted here.

The `send` mutation will no longer return underlying transaction informations, I therefore propose to wire with the `send` subscription instead.

A little fix has been made in the error handling, by fetching the transaction code we are able to know if the transaction was accepted or not in the blockchain's mempool.

Additionally, as fund requests can now take a non negligible amount of time I took the opportunity to introduce a progress bar. A progress bar on which CSS scientists are very welcome to help if relevant (and I think it is 😉).