### PR TITLE
Fix/svg sprite polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "redux-thunk": "^2.4.1",
     "reselect": "^4.1.5",
     "short-uuid": "^4.2.0",
+    "svgxuse": "^1.2.6",
     "ts-bus": "^2.3.1"
   },
   "devDependencies": {

--- a/src/ui/atoms/icon/Icon.tsx
+++ b/src/ui/atoms/icon/Icon.tsx
@@ -3,6 +3,7 @@ import type { DeepReadonly } from 'superTypes'
 import { useTheme } from 'hook/useTheme'
 import type { ThemeContextType } from 'context/themeContext'
 import sprite from 'assets/icons/sprite.svg'
+import 'svgxuse' // svg sprite polyfill
 
 export type IconName =
   | 'add'
@@ -54,7 +55,7 @@ export const Icon: React.FC<IconProps> = ({
 
   return (
     <svg {...(className && { className })} height={`${size}px`} width={`${size}px`}>
-      <use href={`${sprite}#${name}-${theme}`} />
+      <use xlinkHref={`${sprite}#${name}-${theme}`} />
     </svg>
   )
 }

--- a/src/ui/atoms/logo/Logo.tsx
+++ b/src/ui/atoms/logo/Logo.tsx
@@ -4,6 +4,7 @@ import type { ThemeContextType } from 'context/themeContext'
 import { useTheme } from 'hook/useTheme'
 import sprite from 'assets/logos/sprite.svg'
 import './logo.scss'
+import 'svgxuse' // svg sprite polyfill
 
 export type LogoProps = Readonly<{
   /**
@@ -31,7 +32,7 @@ export const Logo: React.FC<LogoProps> = ({ size = 'medium', type = 'logo' }: Lo
 
   return (
     <svg className={imageClassname}>
-      <use href={`${sprite}#${type}-okp4-${theme}`} />
+      <use xlinkHref={`${sprite}#${type}-okp4-${theme}`} />
     </svg>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15454,6 +15454,11 @@ svgo@^2.7.0:
     picocolors "^1.0.0"
     stable "^0.1.8"
 
+svgxuse@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/svgxuse/-/svgxuse-1.2.6.tgz#d6251edd07a75cb28618e0c23e8d4db64936d6be"
+  integrity sha512-0KC0I24LDskC2vaVjUQfFmdtKJk8wFwMYOjCci0HlhBRSc0F86dZRqNBHf6BoS5bibQ7chgnBQWyJCTYkzVuSA==
+
 swap-case@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/swap-case/-/swap-case-2.0.2.tgz#671aedb3c9c137e2985ef51c51f9e98445bf70d9"


### PR DESCRIPTION
This PR adds [svgxuse](https://github.com/Keyamoon/svgxuse) as polyfill for the `<use>` HTML tag.
It allows the load of data URI's with cross-domain in Safari and IE browsers in a `xlink:href` attribute.

⚠️ This polyfill DOES NOT remove the errors in the console because it only comes to fetch the resources if the browser fails to do it
