### PR TITLE
ci(workflow): add JoeyDjr as reviewer and assignee

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,17 +10,19 @@ updates:
       - fredericvilcot
       - ErikssonJoakim
       - lolottetheclash
+      - JoeyDjr
     assignees:
       - ccamel
       - fredericvilcot
       - lolottetheclash
+      - JoeyDjr
     open-pull-requests-limit: 5
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
     reviewers:
-      - amimart
+      - JoeyDjr
       - ccamel
       - fredericvilcot
       - ErikssonJoakim
@@ -29,4 +31,5 @@ updates:
       - ccamel
       - fredericvilcot
       - lolottetheclash
+      - JoeyDjr
     open-pull-requests-limit: 5


### PR DESCRIPTION
This PR adds @JoeyDjr as reviewer and assignee for `dependabot` PR's.
It also removes @amimart from `npm` reviews to avoid unnecessary pollution.