### PR TITLE
docs(storybook): fix icon size story for show code

### DIFF
--- a/stories/atoms/components/icon/icon.stories.mdx
+++ b/stories/atoms/components/icon/icon.stories.mdx
@@ -129,7 +129,7 @@ By `default` the size is **30** pixels.
 
 <Canvas>
   <Story name="Size">
-    {args => {
+    {() => {
       const sizes = [15, 30, 50, 80]
       return (
         <div


### PR DESCRIPTION
This PR is about fixing the "Show code" in the "Size" pat of the `Icon` component story.

before : 
<img width="815" alt="image" src="https://user-images.githubusercontent.com/107192362/185360156-dafff152-1b65-4ed7-b062-47f63cc67d0f.png">

after : 
<img width="813" alt="image" src="https://user-images.githubusercontent.com/107192362/185360332-633ee4af-0f36-4599-8c95-00d81051c627.png">
