### PR TITLE
docs(storybook): fix list component story

### DIFF
--- a/stories/atoms/components/list/List.stories.mdx
+++ b/stories/atoms/components/list/List.stories.mdx
@@ -2,6 +2,7 @@ import { ArgsTable, Meta, Story } from '@storybook/addon-docs'
 import { ThemeProvider } from 'ui/atoms/theme/ThemeProvider'
 import { ThemeSwitcher } from 'ui/atoms/theme/ThemeSwitcher'
 import { List } from 'ui/atoms/list/List'
+import { Icon } from 'ui/atoms/icon/Icon'
 
 <Meta
   title="Atoms/List"


### PR DESCRIPTION
This PR fix the story for the `List` component that doesn't display the Icon because it is missing an import.