### PR TITLE
Docs/refactor button story

### DIFF
--- a/stories/atoms/components/button/Button.stories.mdx
+++ b/stories/atoms/components/button/Button.stories.mdx
@@ -27,7 +27,7 @@ import '../component.scss'
 
 # Button
 
-> Communicate actions that users can take.
+> Communicates actions that users can take.
 
 [![stability-unstable](https://img.shields.io/badge/stability-unstable-yellow.svg)](https://github.com/emersion/stability-badges#unstable)
 
@@ -77,7 +77,7 @@ that will help users to find the action they're looking for.
 
 ## Label
 
-The `label` is the text description of Button aswell as its [title](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title).
+The `label` is the text description of Button as well as its [title](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title).
 If Button is an **icon** `variant` the `label` is not shown, however it is still there as a title attribut used for the [tooltip](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tooltip_Role).
 
 The `label` can have any length however Button width will never exceed 273px.
@@ -94,7 +94,7 @@ The `label` can have any length however Button width will never exceed 273px.
       }}
     >
       <Button label="Short label" />
-      <Button label="Here is how the button acts when you have a long label" />
+      <Button label="Here is how the button acts when it has a long label" />
       <Button label="icon button" variant="icon" icon={<Icon name="profile" size={22} />} />
     </div>
   </Story>
@@ -102,7 +102,7 @@ The `label` can have any length however Button width will never exceed 273px.
 
 ## Icon
 
-`Icon` allows for the creation of an icon button by passing the icon of your choice. It simply takes any node element as value.
+`Icon` allows for the creation of an icon button by passing the icon of your choice. It simply takes any node element as a value.
 
 Requires Button to be an **icon** `variant`, without it the button content will stay `label`.
 
@@ -132,7 +132,7 @@ Button is available in three styled versions:
 
 - **Primary** (default): A rectangular version, symbol of the brand and which reinforces the cosmic atmosphere.
 - **Secondary**: A rounded version, softer, allowing to adapt in particular to smaller screens.
-- **Icon**: Sets the button to be an icon button, requires users to supply an `icon` property.
+- **Icon**: Sets the button to be an icon button, requires you to supply an `icon` property.
 
 <Canvas>
   <Story name="Variants">
@@ -213,7 +213,8 @@ By default `backgroundColor` is **primary**.
 
 ## Disabled
 
-Button can be `disabled` at any time, thus preventing any user interaction.
+Button can be `disabled` at any time, thus preventing any user interaction. This is indicated by a change in background color
+and cursor.
 
 <Canvas>
   <Story name="Disabled">

--- a/stories/atoms/components/button/Button.stories.mdx
+++ b/stories/atoms/components/button/Button.stories.mdx
@@ -96,6 +96,32 @@ The `label` can have any length however Button width will never exceed 273px.
   </Story>
 </Canvas>
 
+## Icon
+
+`Icon` allows for the creation of an icon button by passing the icon of your choice. It simply takes any node element as value.
+
+Requires Button to be an **icon** `variant`, without it the button content will stay `label`.
+
+<Canvas>
+  <Story name="Icon">
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+        gap: '50px'
+      }}
+    >
+      <Button label="icon button" icon={<Icon name="calendar" size={22} />} variant="icon" />
+      <Button
+        label="Icon passed without the icon variant"
+        icon={<Icon name="calendar" size={22} />}
+      />
+    </div>
+  </Story>
+</Canvas>
+
 ## Variants
 
 Button is available in three styled versions:
@@ -222,7 +248,7 @@ together with the `label`.
 ## OnClick
 
 `onClick` is what makes the magic happen, without it the button has no corresponding action.
-The function passed as value should correspond to the action described in `label`.
+It is triggered when a click is registered on the button.
 
 <Canvas>
   <Story name="OnClick">

--- a/stories/atoms/components/button/Button.stories.mdx
+++ b/stories/atoms/components/button/Button.stories.mdx
@@ -1,5 +1,6 @@
 import { ArgsTable, Meta, Story, Canvas } from '@storybook/addon-docs'
 import { useState } from 'react'
+import { useTheme } from 'hook/useTheme'
 import { Button } from 'ui/atoms/button/Button'
 import { ThemeProvider } from 'ui/atoms/theme/ThemeProvider'
 import { ThemeSwitcher } from 'ui/atoms/theme/ThemeSwitcher'
@@ -50,25 +51,28 @@ that will help users to find the action they're looking for.
   }}
   args={{
     label: 'Connect wallet',
-    icon: <Icon name="wallet" size={22} />,
     variant: 'primary',
     size: 'medium',
     backgroundColor: 'primary',
     disabled: false
   }}
 >
-  {args => (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        gap: '25px'
-      }}
-    >
-      <Button {...args} />
-    </div>
-  )}
+  {args => {
+    const { theme } = useTheme()
+    const invert = theme === 'light'
+    return (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: '25px'
+        }}
+      >
+        <Button {...args} icon={<Icon name="wallet" size={22} invertColor={invert} />} />
+      </div>
+    )
+  }}
 </Story>
 
 ## Properties
@@ -84,19 +88,29 @@ The `label` can have any length however Button width will never exceed 273px.
 
 <Canvas>
   <Story name="Label">
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        flexWrap: 'wrap',
-        gap: '50px'
-      }}
-    >
-      <Button label="Short label" />
-      <Button label="Here is how the button acts when it has a long label" />
-      <Button label="icon button" variant="icon" icon={<Icon name="profile" size={22} />} />
-    </div>
+    {() => {
+      const { theme } = useTheme()
+      const invert = theme === 'light'
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+            gap: '50px'
+          }}
+        >
+          <Button label="Short label" />
+          <Button label="Here is how the button acts when it has a long label" />
+          <Button
+            label="icon button"
+            variant="icon"
+            icon={<Icon name="profile" size={22} invertColor={invert} />}
+          />
+        </div>
+      )
+    }}
   </Story>
 </Canvas>
 
@@ -108,21 +122,31 @@ Requires Button to be an **icon** `variant`, without it the button content will 
 
 <Canvas>
   <Story name="Icon">
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        flexWrap: 'wrap',
-        gap: '50px'
-      }}
-    >
-      <Button label="icon button" icon={<Icon name="calendar" size={22} />} variant="icon" />
-      <Button
-        label="Icon passed without the icon variant"
-        icon={<Icon name="calendar" size={22} />}
-      />
-    </div>
+    {() => {
+      const { theme } = useTheme()
+      const invert = theme === 'light'
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+            gap: '50px'
+          }}
+        >
+          <Button
+            label="icon button"
+            icon={<Icon name="calendar" size={22} invertColor={invert} />}
+            variant="icon"
+          />
+          <Button
+            label="Icon passed without the icon variant"
+            icon={<Icon name="calendar" size={22} />}
+          />
+        </div>
+      )
+    }}
   </Story>
 </Canvas>
 
@@ -136,25 +160,31 @@ Button is available in three styled versions:
 
 <Canvas>
   <Story name="Variants">
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        flexWrap: 'wrap',
-        gap: '50px'
-      }}
-    >
-      <Button backgroundColor="primary" variant="primary" label="Primary" size="medium" />
-      <Button backgroundColor="primary" variant="secondary" label="Secondary" size="medium" />
-      <Button
-        backgroundColor="primary"
-        variant="icon"
-        label="Icon"
-        size="medium"
-        icon={<Icon name="wallet" size={22} />}
-      />
-    </div>
+    {() => {
+      const { theme } = useTheme()
+      const invert = theme === 'light'
+      return (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+            gap: '50px'
+          }}
+        >
+          <Button backgroundColor="primary" variant="primary" label="Primary" size="medium" />
+          <Button backgroundColor="primary" variant="secondary" label="Secondary" size="medium" />
+          <Button
+            backgroundColor="primary"
+            variant="icon"
+            label="Icon"
+            size="medium"
+            icon={<Icon name="wallet" size={22} invertColor={invert} />}
+          />
+        </div>
+      )
+    }}
   </Story>
 </Canvas>
 
@@ -236,17 +266,29 @@ together with the `label`.
 
 <Canvas>
   <Story name="Left / Right Icon">
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'center',
-        flexWrap: 'wrap',
-        gap: '50px'
-      }}
-    >
-      <Button leftIcon={<Icon name="wallet" size={22} />} label="Get wallet address" />
-      <Button label="Add wallet" rightIcon={<Icon name="add" size={22} />} />
-    </div>
+    {() => {
+      const { theme } = useTheme()
+      const invert = theme === 'light'
+      return (
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+            gap: '50px'
+          }}
+        >
+          <Button
+            leftIcon={<Icon name="wallet" size={22} invertColor={invert} />}
+            label="Get wallet address"
+          />
+          <Button
+            label="Add wallet"
+            rightIcon={<Icon name="add" size={22} invertColor={invert} />}
+          />
+        </div>
+      )
+    }}
   </Story>
 </Canvas>
 

--- a/stories/atoms/components/button/Button.stories.mdx
+++ b/stories/atoms/components/button/Button.stories.mdx
@@ -1,8 +1,12 @@
 import { ArgsTable, Meta, Story, Canvas } from '@storybook/addon-docs'
+import { useState } from 'react'
 import { Button } from 'ui/atoms/button/Button'
 import { ThemeProvider } from 'ui/atoms/theme/ThemeProvider'
 import { ThemeSwitcher } from 'ui/atoms/theme/ThemeSwitcher'
 import { Icon } from 'ui/atoms/icon/Icon'
+import { Toast } from 'ui/atoms/toast/Toast'
+import { Typography } from 'ui/atoms/typography/Typography'
+import '../component.scss'
 
 <Meta
   title="Atoms/Button"
@@ -23,27 +27,26 @@ import { Icon } from 'ui/atoms/icon/Icon'
 
 # Button
 
-> Communicate _actions_ that users can take.
+> Communicate actions that users can take.
 
 [![stability-unstable](https://img.shields.io/badge/stability-unstable-yellow.svg)](https://github.com/emersion/stability-badges#unstable)
 
-## Overview
+## Description
 
-### Description
+Buttons are mainly used to give the user options to act. They help users to find
+the most important actions throughout UI and enables them to perform these actions.
 
-Buttons are mainly used to show the user’s choice of options for actions. A button helps the users to find
-the most important actions throughout UI and enables them to perform these actions.  
-By using one or more of the **content** properties it's possible to create appealing and intuitive buttons
+By using one or more of the button properties it's possible to create appealing and intuitive buttons
 that will help users to find the action they're looking for.
 
----
+## Overview
 
 <Story
   name="Overview"
   argTypes={{
-    icon: { control: false, table: { type: { summary: 'JSX.Element' } } },
-    leftIcon: { control: false, table: { type: { summary: 'JSX.Element' } } },
-    rightIcon: { control: false, table: { type: { summary: 'JSX.Element' } } }
+    icon: { control: false, table: { type: { summary: 'Node' } } },
+    leftIcon: { control: false, table: { type: { summary: 'Node' } } },
+    rightIcon: { control: false, table: { type: { summary: 'Node' } } }
   }}
   args={{
     label: 'Connect wallet',
@@ -64,155 +67,204 @@ that will help users to find the action they're looking for.
   )}
 </Story>
 
----
-
-### Properties
+## Properties
 
 <ArgsTable story="Overview" />
 
+## Label
+
+The `label` is the text description of **Button** aswell as its [title](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title).
+If **Button** is an **icon** `variant` the `label` is not shown, however it is still there as a title attribut used for the [tooltip](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tooltip_Role).
+
+The `label` can have any length however **Button** width will never exceed 273px.
+
+<Canvas>
+  <Story name="Label">
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+        gap: '50px'
+      }}
+    >
+      <Button label="Short label" />
+      <Button label="Here is how the button acts when you have a long label" />
+    </div>
+  </Story>
+</Canvas>
+
 ## Variants
 
-The `Button` component is available in two style versions:
+**Button** is available in three styled versions:
 
-- **Primary**: a rectangular version, symbol of the brand and which reinforces the cosmic atmosphere.
-- **Secondary**: a rounded version, softer, allowing to adapt in particular to smaller screens.
-- **Icon**: sets the button to be an icon button, requires users to supply an `icon` property.
+- **Primary** (_default_): A rectangular version, symbol of the brand and which reinforces the cosmic atmosphere.
+- **Secondary**: A rounded version, softer, allowing to adapt in particular to smaller screens.
+- **Icon**: Sets the button to be an icon button, requires users to supply an `icon` property.
 
 <Canvas>
   <Story name="Variants">
-    {args => (
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          flexWrap: 'wrap',
-          gap: '25px'
-        }}
-      >
-        <Button backgroundColor="primary" variant="primary" label="Primary" size="medium" />
-        <Button backgroundColor="primary" variant="secondary" label="Secondary" size="medium" />
-        <Button
-          backgroundColor="primary"
-          variant="icon"
-          label="Icon"
-          size="medium"
-          icon={<Icon name="wallet" size={22} />}
-        />
-      </div>
-    )}
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+        gap: '50px'
+      }}
+    >
+      <Button backgroundColor="primary" variant="primary" label="Primary" size="medium" />
+      <Button backgroundColor="primary" variant="secondary" label="Secondary" size="medium" />
+      <Button
+        backgroundColor="primary"
+        variant="icon"
+        label="Icon"
+        size="medium"
+        icon={<Icon name="wallet" size={22} />}
+      />
+    </div>
   </Story>
 </Canvas>
 
 ## Sizes
 
-The `Button` component comes with three different sizes to allow its use according to its location within the interface.
+There are three different sizes to allow **Button** to be used according to its location within the interface.
 
-- **Small**: particularly suitable for small screens and must not saturate the space. This size should also be used for integrations in content spaces such as cards, footers, etc...
-- **Medium**: makes it possible to adapt to a greater number of uses.
-- **Large**: particularly suitable for large screens or to embed icons befor or after.
+- **Small**: particularly suitable for small screens and must not saturate the space. This size should also be used for integrations in content spaces such as cards, footers, etc.
+- **Medium** (_default_): makes it possible to adapt to a greater number of uses.
+- **Large**: particularly suitable for large screens or in conjonction with `leftIcon` / `rightIcon`.
 
 <Canvas>
   <Story name="Sizes">
-    {args => (
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          flexWrap: 'wrap',
-          gap: '25px'
-        }}
-      >
-        <Button backgroundColor="primary" variant="primary" label="Small" size="small" />
-        <Button backgroundColor="primary" variant="primary" label="Medium" size="medium" />
-        <Button backgroundColor="primary" variant="primary" label="Large" size="large" />
-      </div>
-    )}
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+        gap: '50px'
+      }}
+    >
+      <Button backgroundColor="primary" variant="primary" label="Small" size="small" />
+      <Button backgroundColor="primary" variant="primary" label="Medium" size="medium" />
+      <Button backgroundColor="primary" variant="primary" label="Large" size="large" />
+    </div>
   </Story>
 </Canvas>
 
 ## Background colors
 
-The background color of the `Button` component is declined according to the selected theme and allows to better mark a user action.
+**Button** have a palette of background colors to choose from and allows to better mark a user action.
+The background color can be a visual aid as to what type of action the button executes.
+
+By _default_ `backgroundColor` is **primary**.
 
 <Canvas>
   <Story name="Background colors">
-    {args => (
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: '25px',
-          flexWrap: 'wrap'
-        }}
-      >
-        <Button backgroundColor="primary" variant="primary" label="Primary" size="medium" />
-        <Button backgroundColor="secondary" variant="primary" label="Secondary" size="medium" />
-        <Button backgroundColor="success" variant="primary" label="Success" size="medium" />
-        <Button backgroundColor="error" variant="primary" label="Error" size="medium" />
-        <Button backgroundColor="warning" variant="primary" label="Warning" size="medium" />
-        <Button backgroundColor="info" variant="primary" label="Info" size="medium" />
-      </div>
-    )}
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        gap: '25px',
+        flexWrap: 'wrap'
+      }}
+    >
+      <Button backgroundColor="primary" variant="primary" label="Primary" size="medium" />
+      <Button backgroundColor="secondary" variant="primary" label="Secondary" size="medium" />
+      <Button backgroundColor="success" variant="primary" label="Success" size="medium" />
+      <Button backgroundColor="error" variant="primary" label="Error" size="medium" />
+      <Button backgroundColor="warning" variant="primary" label="Warning" size="medium" />
+      <Button backgroundColor="info" variant="primary" label="Info" size="medium" />
+    </div>
   </Story>
 </Canvas>
 
 ## Disabled
 
-The `Button` can be disabled at any time, thus preventing any user interaction.
+**Button** can be `disabled` at any time, thus preventing any user interaction.
 
 <Canvas>
   <Story name="Disabled">
-    {args => (
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: '25px',
-          flexWrap: 'wrap'
-        }}
-      >
-        <Button disabled variant="primary" label="I'm disabled" size="medium" />
-      </div>
-    )}
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center'
+      }}
+    >
+      <Button disabled variant="primary" label="I'm disabled" size="medium" />
+    </div>
   </Story>
 </Canvas>
 
-## Content
+## Left / Right Icon
 
-The content can be customized to fit users needs through its properties `label`, `icon`,
-`leftIcon` and `rightIcon`.
-
-- `label` is the only obligatory property and is used to clearly indicate what action will be triggered, through the
-  tooltip and text.
-- `icon` sets the icon for the **variant** 'icon'.
-- `leftIcon` and `rightIcon` are auxilliary elements giving great freedom to embellish the button
-  together with the label.
+`leftIcon` and `rightIcon` are auxilliary elements giving great freedom to embellish the button
+together with the `label`.
 
 <Canvas>
-  <Story name="Content">
-    {args => (
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: '25px',
-          flexWrap: 'wrap'
-        }}
-      >
-        <Button icon={<Icon name="wallet" size={22} />} label="wallet" variant="icon" />
-        <Button icon={<Icon name="wallet" size={22} />} label="wallet" variant="icon" />
-        <Button leftIcon={<Icon name="wallet" size={22} />} label="Get wallet address" />
-        <Button
-          label="Add wallet"
-          leftIcon={<Icon name="wallet" size={22} />}
-          rightIcon={<Icon name="add" size={22} />}
-        />
-      </div>
-    )}
+  <Story name="Left / Right Icon">
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+        gap: '50px'
+      }}
+    >
+      <Button leftIcon={<Icon name="wallet" size={22} />} label="Get wallet address" />
+      <Button label="Add wallet" rightIcon={<Icon name="add" size={22} />} />
+    </div>
+  </Story>
+</Canvas>
+
+## OnClick
+
+`onClick` is what makes the magic happen, without it the button has no corresponding action.
+The function passed as value should correspond to the action described in `label`.
+
+<Canvas>
+  <Story name="OnClick">
+    {() => {
+      const [state, setState] = useState({ name: '', isOpened: false })
+      const handleState = (name, isOpened) => () => {
+        setState({ name, isOpened })
+      }
+      return (
+        <div>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'center'
+            }}
+          >
+            <Button label="Click me!" onClick={handleState('button clicked', true)} />
+          </div>
+          <Toast
+            description={
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                <Typography color="highlighted-text" fontSize="small" fontWeight="light">
+                  {`Like this component? See `}
+                  <Typography color="highlighted-text" fontSize="small" fontWeight="bold">
+                    <a
+                      href="/?path=/docs/atoms-toast--overview"
+                      rel="author noreferrer"
+                      target="_blank"
+                      style={{ color: 'inherit' }}
+                    >
+                      Toast
+                    </a>
+                  </Typography>
+                </Typography>
+              </div>
+            }
+            isOpened={Object.values(state).includes('button clicked') ? state['isOpened'] : false}
+            onOpenChange={handleState('button clicked', false)}
+            title="Button clicked!"
+            severityLevel="info"
+          />
+        </div>
+      )
+    }}
   </Story>
 </Canvas>

--- a/stories/atoms/components/button/Button.stories.mdx
+++ b/stories/atoms/components/button/Button.stories.mdx
@@ -180,7 +180,7 @@ Button is available in three styled versions:
             variant="icon"
             label="Icon"
             size="medium"
-            icon={<Icon name="wallet" size={22} invertColor={invert} />}
+            icon={<Icon name="alert" size={22} invertColor={invert} />}
           />
         </div>
       )
@@ -317,9 +317,9 @@ It is triggered when a click is registered on the button.
           <Toast
             description={
               <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <Typography color="highlighted-text" fontSize="small" fontWeight="light">
+                <Typography color="inverted-text" fontSize="small" fontWeight="light">
                   {`Like this component? See `}
-                  <Typography color="highlighted-text" fontSize="small" fontWeight="bold">
+                  <Typography color="inverted-text" fontSize="small" fontWeight="bold">
                     <a
                       href="/?path=/docs/atoms-toast--overview"
                       rel="author noreferrer"
@@ -334,8 +334,12 @@ It is triggered when a click is registered on the button.
             }
             isOpened={opened}
             onOpenChange={handleOpened(false)}
-            title="Button clicked!"
-            severityLevel="success"
+            title={
+              <Typography color="inverted-text" fontSize="small" fontWeight="bold">
+                Button clicked!
+              </Typography>
+            }
+            severityLevel="info"
           />
         </div>
       )

--- a/stories/atoms/components/button/Button.stories.mdx
+++ b/stories/atoms/components/button/Button.stories.mdx
@@ -1,4 +1,4 @@
-import { ArgsTable, Meta, Story, Canvas, Preview, Props } from '@storybook/addon-docs'
+import { ArgsTable, Meta, Story, Canvas } from '@storybook/addon-docs'
 import { Button } from 'ui/atoms/button/Button'
 import { ThemeProvider } from 'ui/atoms/theme/ThemeProvider'
 import { ThemeSwitcher } from 'ui/atoms/theme/ThemeSwitcher'

--- a/stories/atoms/components/button/Button.stories.mdx
+++ b/stories/atoms/components/button/Button.stories.mdx
@@ -35,9 +35,9 @@ import '../component.scss'
 ## Description
 
 Buttons are mainly used to give the user options to act. They help users to find
-the most important actions throughout UI and enables them to perform these actions.
+the most important actions through the UI and enable them to perform these actions.
 
-By using one or more of the button properties it's possible to create appealing and intuitive buttons
+By using one or more of the button properties, it's possible to create appealing and intuitive buttons
 that will help users to find the action they're looking for.
 
 ## Overview
@@ -59,7 +59,7 @@ that will help users to find the action they're looking for.
 >
   {args => {
     const { theme } = useTheme()
-    const invert = theme === 'light'
+    const isLightTheme = theme === 'light'
     return (
       <div
         style={{
@@ -69,7 +69,7 @@ that will help users to find the action they're looking for.
           gap: '25px'
         }}
       >
-        <Button {...args} icon={<Icon name="wallet" size={22} invertColor={invert} />} />
+        <Button {...args} icon={<Icon name="wallet" size={22} invertColor={isLightTheme} />} />
       </div>
     )
   }}
@@ -81,8 +81,10 @@ that will help users to find the action they're looking for.
 
 ## Label
 
-The `label` is the text description of Button as well as its [title](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title).
-If Button is an **icon** `variant` the `label` is not shown, however it is still there as a title attribut used for the [tooltip](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tooltip_Role).
+The `label` is the text description of Button that helps communicate what happens after the click.
+If Button is an **icon** `variant`, the `label` is not shown, however it is still there as a title
+attribut used for the [tooltip](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tooltip_Role)
+(as you can see by hovering your mouse over the icon button below).
 
 The `label` can have any length however Button width will never exceed 273px.
 
@@ -90,7 +92,7 @@ The `label` can have any length however Button width will never exceed 273px.
   <Story name="Label">
     {() => {
       const { theme } = useTheme()
-      const invert = theme === 'light'
+      const isLightTheme = theme === 'light'
       return (
         <div
           style={{
@@ -104,9 +106,9 @@ The `label` can have any length however Button width will never exceed 273px.
           <Button label="Short label" />
           <Button label="Here is how the button acts when it has a long label" />
           <Button
-            label="icon button"
+            label="I'm the label of the icon button"
             variant="icon"
-            icon={<Icon name="profile" size={22} invertColor={invert} />}
+            icon={<Icon name="profile" size={22} invertColor={isLightTheme} />}
           />
         </div>
       )
@@ -116,15 +118,15 @@ The `label` can have any length however Button width will never exceed 273px.
 
 ## Icon
 
-`Icon` allows for the creation of an icon button by passing the icon of your choice. It simply takes any node element as a value.
+`Icon` turns the button into a more concise, unlabeled element. For that, you can pass the icon of your choice as a value.
 
-Requires Button to be an **icon** `variant`, without it the button content will stay `label`.
+Requires Button to be an **icon** `variant`. Without it, the button content will remain `label`.
 
 <Canvas>
   <Story name="Icon">
     {() => {
       const { theme } = useTheme()
-      const invert = theme === 'light'
+      const isLightTheme = theme === 'light'
       return (
         <div
           style={{
@@ -137,7 +139,7 @@ Requires Button to be an **icon** `variant`, without it the button content will 
         >
           <Button
             label="icon button"
-            icon={<Icon name="calendar" size={22} invertColor={invert} />}
+            icon={<Icon name="calendar" size={22} invertColor={isLightTheme} />}
             variant="icon"
           />
           <Button
@@ -154,15 +156,15 @@ Requires Button to be an **icon** `variant`, without it the button content will 
 
 Button is available in three styled versions:
 
-- **Primary** (default): A rectangular version, symbol of the brand and which reinforces the cosmic atmosphere.
-- **Secondary**: A rounded version, softer, allowing to adapt in particular to smaller screens.
-- **Icon**: Sets the button to be an icon button, requires you to supply an `icon` property.
+- **primary** (default): A rectangular version, symbol of the brand and which reinforces the cosmic atmosphere.
+- **secondary**: A rounded version, softer, allowing to adapt in particular to smaller screens.
+- **icon**: Sets the button to be an icon button, requires you to supply an `icon` property.
 
 <Canvas>
   <Story name="Variants">
     {() => {
       const { theme } = useTheme()
-      const invert = theme === 'light'
+      const isLightTheme = theme === 'light'
       return (
         <div
           style={{
@@ -180,7 +182,7 @@ Button is available in three styled versions:
             variant="icon"
             label="Icon"
             size="medium"
-            icon={<Icon name="alert" size={22} invertColor={invert} />}
+            icon={<Icon name="alert" size={22} invertColor={isLightTheme} />}
           />
         </div>
       )
@@ -192,9 +194,9 @@ Button is available in three styled versions:
 
 There are three different sizes to allow Button to be used according to its location within the interface.
 
-- **Small**: particularly suitable for small screens and must not saturate the space. This size should also be used for integrations in content spaces such as cards, footers, etc.
-- **Medium** (default): makes it possible to adapt to a greater number of uses.
-- **Large**: particularly suitable for large screens or in conjonction with `leftIcon` / `rightIcon`.
+- **small**: Suitable for small screens and must not saturate the space. This size should also be used for integrations in content spaces such as cards, footers, etc.
+- **medium** (default): Makes it possible to adapt to a greater number of uses.
+- **large**: Appropriate for large screens or in conjonction with `leftIcon` / `rightIcon` properties.
 
 <Canvas>
   <Story name="Sizes">
@@ -265,10 +267,10 @@ and cursor.
 together with the `label`.
 
 <Canvas>
-  <Story name="Left / Right Icon">
+  <Story name="Left / right Icon">
     {() => {
       const { theme } = useTheme()
-      const invert = theme === 'light'
+      const isLightTheme = theme === 'light'
       return (
         <div
           style={{
@@ -279,12 +281,12 @@ together with the `label`.
           }}
         >
           <Button
-            leftIcon={<Icon name="wallet" size={22} invertColor={invert} />}
+            leftIcon={<Icon name="wallet" size={22} invertColor={isLightTheme} />}
             label="Get wallet address"
           />
           <Button
             label="Add wallet"
-            rightIcon={<Icon name="add" size={22} invertColor={invert} />}
+            rightIcon={<Icon name="add" size={22} invertColor={isLightTheme} />}
           />
         </div>
       )
@@ -300,9 +302,9 @@ It is triggered when a click is registered on the button.
 <Canvas>
   <Story name="OnClick">
     {() => {
-      const [opened, setOpened] = useState(false)
-      const handleOpened = isOpened => () => {
-        setOpened(isOpened)
+      const [isOpened, setIsOpened] = useState(false)
+      const handleOpen = () => {
+        setIsOpened(prevState => !prevState)
       }
       return (
         <div>
@@ -312,7 +314,7 @@ It is triggered when a click is registered on the button.
               justifyContent: 'center'
             }}
           >
-            <Button label="Click me!" onClick={handleOpened(true)} />
+            <Button label="Click me!" onClick={handleOpen} />
           </div>
           <Toast
             description={
@@ -332,8 +334,8 @@ It is triggered when a click is registered on the button.
                 </Typography>
               </div>
             }
-            isOpened={opened}
-            onOpenChange={handleOpened(false)}
+            isOpened={isOpened}
+            onOpenChange={handleOpen}
             title={
               <Typography color="inverted-text" fontSize="small" fontWeight="bold">
                 Button clicked!

--- a/stories/atoms/components/button/Button.stories.mdx
+++ b/stories/atoms/components/button/Button.stories.mdx
@@ -73,10 +73,10 @@ that will help users to find the action they're looking for.
 
 ## Label
 
-The `label` is the text description of **Button** aswell as its [title](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title).
-If **Button** is an **icon** `variant` the `label` is not shown, however it is still there as a title attribut used for the [tooltip](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tooltip_Role).
+The `label` is the text description of Button aswell as its [title](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title).
+If Button is an **icon** `variant` the `label` is not shown, however it is still there as a title attribut used for the [tooltip](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tooltip_Role).
 
-The `label` can have any length however **Button** width will never exceed 273px.
+The `label` can have any length however Button width will never exceed 273px.
 
 <Canvas>
   <Story name="Label">
@@ -91,15 +91,16 @@ The `label` can have any length however **Button** width will never exceed 273px
     >
       <Button label="Short label" />
       <Button label="Here is how the button acts when you have a long label" />
+      <Button label="icon button" variant="icon" icon={<Icon name="profile" size={22} />} />
     </div>
   </Story>
 </Canvas>
 
 ## Variants
 
-**Button** is available in three styled versions:
+Button is available in three styled versions:
 
-- **Primary** (_default_): A rectangular version, symbol of the brand and which reinforces the cosmic atmosphere.
+- **Primary** (default): A rectangular version, symbol of the brand and which reinforces the cosmic atmosphere.
 - **Secondary**: A rounded version, softer, allowing to adapt in particular to smaller screens.
 - **Icon**: Sets the button to be an icon button, requires users to supply an `icon` property.
 
@@ -129,10 +130,10 @@ The `label` can have any length however **Button** width will never exceed 273px
 
 ## Sizes
 
-There are three different sizes to allow **Button** to be used according to its location within the interface.
+There are three different sizes to allow Button to be used according to its location within the interface.
 
 - **Small**: particularly suitable for small screens and must not saturate the space. This size should also be used for integrations in content spaces such as cards, footers, etc.
-- **Medium** (_default_): makes it possible to adapt to a greater number of uses.
+- **Medium** (default): makes it possible to adapt to a greater number of uses.
 - **Large**: particularly suitable for large screens or in conjonction with `leftIcon` / `rightIcon`.
 
 <Canvas>
@@ -155,10 +156,10 @@ There are three different sizes to allow **Button** to be used according to its 
 
 ## Background colors
 
-**Button** have a palette of background colors to choose from and allows to better mark a user action.
+Button has a palette of background colors to choose from and allows to better mark a user action.
 The background color can be a visual aid as to what type of action the button executes.
 
-By _default_ `backgroundColor` is **primary**.
+By default `backgroundColor` is **primary**.
 
 <Canvas>
   <Story name="Background colors">
@@ -182,7 +183,7 @@ By _default_ `backgroundColor` is **primary**.
 
 ## Disabled
 
-**Button** can be `disabled` at any time, thus preventing any user interaction.
+Button can be `disabled` at any time, thus preventing any user interaction.
 
 <Canvas>
   <Story name="Disabled">
@@ -226,9 +227,9 @@ The function passed as value should correspond to the action described in `label
 <Canvas>
   <Story name="OnClick">
     {() => {
-      const [state, setState] = useState({ name: '', isOpened: false })
-      const handleState = (name, isOpened) => () => {
-        setState({ name, isOpened })
+      const [opened, setOpened] = useState(false)
+      const handleOpened = isOpened => () => {
+        setOpened(isOpened)
       }
       return (
         <div>
@@ -238,7 +239,7 @@ The function passed as value should correspond to the action described in `label
               justifyContent: 'center'
             }}
           >
-            <Button label="Click me!" onClick={handleState('button clicked', true)} />
+            <Button label="Click me!" onClick={handleOpened(true)} />
           </div>
           <Toast
             description={
@@ -258,10 +259,10 @@ The function passed as value should correspond to the action described in `label
                 </Typography>
               </div>
             }
-            isOpened={Object.values(state).includes('button clicked') ? state['isOpened'] : false}
-            onOpenChange={handleState('button clicked', false)}
+            isOpened={opened}
+            onOpenChange={handleOpened(false)}
             title="Button clicked!"
-            severityLevel="info"
+            severityLevel="success"
           />
         </div>
       )

--- a/stories/atoms/components/button/Button.stories.mdx
+++ b/stories/atoms/components/button/Button.stories.mdx
@@ -50,7 +50,11 @@ that will help users to find the action they're looking for.
   }}
   args={{
     label: 'Connect wallet',
-    icon: <Icon name="wallet" size={22} />
+    icon: <Icon name="wallet" size={22} />,
+    variant: 'primary',
+    size: 'medium',
+    backgroundColor: 'primary',
+    disabled: false
   }}
 >
   {args => (

--- a/stories/atoms/components/button/Button.stories.mdx
+++ b/stories/atoms/components/button/Button.stories.mdx
@@ -7,14 +7,6 @@ import { Icon } from 'ui/atoms/icon/Icon'
 <Meta
   title="Atoms/Button"
   component={Button}
-  parameters={{
-    actions: { argTypesRegex: '^on.*' },
-    docs: {
-      source: {
-        type: 'code'
-      }
-    }
-  }}
   decorators={[
     Story => (
       <ThemeProvider>

--- a/stories/atoms/components/button/Button.stories.mdx
+++ b/stories/atoms/components/button/Button.stories.mdx
@@ -269,3 +269,23 @@ The function passed as value should correspond to the action described in `label
     }}
   </Story>
 </Canvas>
+
+## Prerequisites
+
+It is mandatory to wrap the component in a `<ThemeProvider />` for the thematisation to work.
+See <a href="?path=/docs/atoms-brand-identity-theming--theming">Theming</a> for more information.
+
+##### **`app.tsx`**
+
+```tsx
+import React from 'react'
+import { Button, ThemeProvider } from '@okp4/ui'
+
+export const App: React.FC = () => (
+  <React.StrictMode>
+    <ThemeProvider>
+      <Button label="Super label" />
+    </ThemeProvider>
+  </React.StrictMode>
+)
+```


### PR DESCRIPTION
This PR implements #459 for `Button`

Recap of the most important changes:

- conformed descriptions to format (bold **values**, `properties` in back tics, default values in story description).
- Cleaned up redundant code (unused deprecated imports, redundant meta parameters).
- added default values in Overview story args to improve property table, as per [wiki](https://github.com/okp4/ui/wiki/Create-A-Story) specifications.
- ordered stories as they appear in property table.
- Replaced the story Content by stories `label`, `icon` and `left / right icon`.
![Capture d’écran 2022-09-05 à 14 27 55](https://user-images.githubusercontent.com/75730728/188449681-7b3d7f77-5493-4755-a623-d6772b8cacd0.png)
![Capture d’écran 2022-09-05 à 14 27 20](https://user-images.githubusercontent.com/75730728/188449679-4e8c3cfa-ba05-48fe-952f-87bf12b9d5ca.png)
- Added interactivity to `onClick` story.
![Capture d’écran 2022-09-05 à 14 26 39](https://user-images.githubusercontent.com/75730728/188449675-ce5ab615-50a5-4065-b1a7-46ec8983dbb4.png)