### PR TITLE
Add invert theme to Icon

### DIFF
--- a/src/ui/atoms/icon/Icon.tsx
+++ b/src/ui/atoms/icon/Icon.tsx
@@ -44,18 +44,25 @@ export type IconProps = {
    * Custom className to add some additional style.
    */
   readonly className?: string
+  /**
+   * Defines if icon theme style is inverted.
+   */
+  readonly invert?: boolean
 }
 
 export const Icon: React.FC<IconProps> = ({
   name,
   size = 30,
-  className
+  className,
+  invert
 }: DeepReadonly<IconProps>): JSX.Element => {
   const { theme }: ThemeContextType = useTheme()
 
   return (
     <svg {...(className && { className })} height={`${size}px`} width={`${size}px`}>
-      <use xlinkHref={`${sprite}#${name}-${theme}`} />
+      <use
+        xlinkHref={`${sprite}#${name}-${invert ? (theme === 'dark' ? 'light' : 'dark') : theme}`}
+      />
     </svg>
   )
 }

--- a/src/ui/atoms/icon/Icon.tsx
+++ b/src/ui/atoms/icon/Icon.tsx
@@ -45,23 +45,25 @@ export type IconProps = {
    */
   readonly className?: string
   /**
-   * Defines if icon theme style is inverted.
+   * If `true`, the color is inverted according to the current theme.
    */
-  readonly invert?: boolean
+  readonly invertColor?: boolean
 }
 
 export const Icon: React.FC<IconProps> = ({
   name,
   size = 30,
   className,
-  invert
+  invertColor
 }: DeepReadonly<IconProps>): JSX.Element => {
   const { theme }: ThemeContextType = useTheme()
 
   return (
     <svg {...(className && { className })} height={`${size}px`} width={`${size}px`}>
       <use
-        xlinkHref={`${sprite}#${name}-${invert ? (theme === 'dark' ? 'light' : 'dark') : theme}`}
+        xlinkHref={`${sprite}#${name}-${
+          invertColor ? (theme === 'dark' ? 'light' : 'dark') : theme
+        }`}
       />
     </svg>
   )

--- a/stories/atoms/components/icon/icon.scss
+++ b/stories/atoms/components/icon/icon.scss
@@ -14,7 +14,7 @@
   }
 }
 
-.invert {
+.inverted {
   @include with-theme() {
     background: themed('inverted-field');
   }

--- a/stories/atoms/components/icon/icon.scss
+++ b/stories/atoms/components/icon/icon.scss
@@ -16,7 +16,7 @@
 
 .invert {
   @include with-theme() {
-    background: themed('field-high-contrast');
+    background: themed('inverted-field');
   }
 }
 

--- a/stories/atoms/components/icon/icon.scss
+++ b/stories/atoms/components/icon/icon.scss
@@ -14,6 +14,12 @@
   }
 }
 
+.invert {
+  @include with-theme() {
+    background: themed('field-high-contrast');
+  }
+}
+
 .rotate-add {
   transform: rotate(45deg);
 }

--- a/stories/atoms/components/icon/icon.stories.mdx
+++ b/stories/atoms/components/icon/icon.stories.mdx
@@ -180,8 +180,8 @@ As seen in the examples below you can rotate icons, add background colors, anima
 
 ## Invert
 
-The **invert** property allows you to invert the theme of the icon.  
-If it set to `true`, the icon will be in light theme in dark theme and in dark theme in light theme.
+The `invert` property allows you to invert the theme of the icon.  
+If it set to **true**, the icon will be in light theme in dark theme and in dark theme in light theme.
 
 <Canvas>
   <Story name="Invert">

--- a/stories/atoms/components/icon/icon.stories.mdx
+++ b/stories/atoms/components/icon/icon.stories.mdx
@@ -200,7 +200,7 @@ In particular, this makes it possible to better manage high-contrast elements an
           Current theme
         </Typography>
       </div>
-      <div className="icon-card invert">
+      <div className="icon-card inverted">
         <Icon name="wallet" invertColor />
         <Typography as="span" color="inverted-text" fontSize="x-small" fontFamily="secondary">
           Inverse theme

--- a/stories/atoms/components/icon/icon.stories.mdx
+++ b/stories/atoms/components/icon/icon.stories.mdx
@@ -178,13 +178,14 @@ As seen in the examples below you can rotate icons, add background colors, anima
   </Story>
 </Canvas>
 
-## Invert
+## Invert color
 
-The `invert` property allows you to invert the theme of the icon.  
-If it set to **true**, the icon will be in light theme in dark theme and in dark theme in light theme.
+The `invertColor` property allows you to invert the color of the icon, regarding the current theme.  
+If set to **true**, the icon will be displayed in **white** when the light theme is selected and in **blue** when the dark theme is active.
+In particular, this makes it possible to better manage high-contrast elements and thus offer the user an immersive User eXperience.
 
 <Canvas>
-  <Story name="Invert">
+  <Story name="Invert color">
     <div
       style={{
         display: 'grid',
@@ -200,7 +201,7 @@ If it set to **true**, the icon will be in light theme in dark theme and in dark
         </Typography>
       </div>
       <div className="icon-card invert">
-        <Icon name="wallet" invert />
+        <Icon name="wallet" invertColor />
         <Typography as="span" color="inverted-text" fontSize="x-small" fontFamily="secondary">
           Inverse theme
         </Typography>

--- a/stories/atoms/components/icon/icon.stories.mdx
+++ b/stories/atoms/components/icon/icon.stories.mdx
@@ -178,6 +178,37 @@ As seen in the examples below you can rotate icons, add background colors, anima
   </Story>
 </Canvas>
 
+## Invert
+
+The **invert** property allows you to invert the theme of the icon.  
+If it set to `true`, the icon will be in light theme in dark theme and in dark theme in light theme.
+
+<Canvas>
+  <Story name="Invert">
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(150px,150px))',
+        justifyContent: 'center',
+        gap: '30px'
+      }}
+    >
+      <div className="icon-card">
+        <Icon name="wallet" />
+        <Typography as="span" color="text" fontSize="x-small" fontFamily="secondary">
+          Current theme
+        </Typography>
+      </div>
+      <div className="icon-card invert">
+        <Icon name="wallet" invert />
+        <Typography as="span" color="inverted-text" fontSize="x-small" fontFamily="secondary">
+          Inverse theme
+        </Typography>
+      </div>
+    </div>
+  </Story>
+</Canvas>
+
 ## Prerequisites
 
 It is mandatory to wrap the component in a `<ThemeProvider />` for the thematisation to work.


### PR DESCRIPTION
This PR adds the `invert` prop to `Icon` to invert the icon theme color.
This feature is implemented to allow icons to stand out on high contrast backgrounds

<img width="1040" alt="image" src="https://user-images.githubusercontent.com/107192362/186903984-b3638eb5-687f-48bb-a4f0-e264bbf6dd8d.png">

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/107192362/186904034-6787bc7a-c82e-4efb-8987-6cd0cc892f70.png">

