### PR TITLE
Refactor/task domain

### DIFF
--- a/src/adapters/task/mapper/task.mapper.ts
+++ b/src/adapters/task/mapper/task.mapper.ts
@@ -1,7 +1,8 @@
 /* eslint-disable functional/no-let */
 import { TaskBuilder } from 'domain/task/builder/task/task.builder'
 import type { Task, UpdateTask } from 'domain/task/entity/task'
-import type { AmendTask, CreateTask } from 'domain/task/command/createTask'
+import type { AmendTask } from 'domain/task/command/amendtask'
+import type { CreateTask } from 'domain/task/command/createTask'
 import type { DeepReadonly } from 'superTypes'
 import { UpdateTaskBuilder } from 'domain/task/builder/updateTask/updateTask.builder'
 

--- a/src/adapters/task/mapper/task.mapper.ts
+++ b/src/adapters/task/mapper/task.mapper.ts
@@ -1,0 +1,17 @@
+import { TaskBuilder } from 'domain/task/builder/task/task.builder'
+import type { Task } from 'domain/task/entity/task'
+import type { CreateTask } from 'domain/task/command/createTask'
+import type { DeepReadonly } from 'superTypes'
+
+export class TaskMapper {
+  public static readonly mapCommandPayloadToEntity = (payload: DeepReadonly<CreateTask>): Task =>
+    new TaskBuilder()
+      .withId(payload.id)
+      .withCreationDate(payload.timestamp)
+      .withLastUpdateDate(payload.timestamp)
+      .withInitiator(payload.initiator)
+      .withMessageKey(payload.messageKey)
+      .withType(payload.type)
+      .withStatus(payload.status)
+      .build()
+}

--- a/src/adapters/task/mapper/task.mapper.ts
+++ b/src/adapters/task/mapper/task.mapper.ts
@@ -1,10 +1,11 @@
 import { TaskBuilder } from 'domain/task/builder/task/task.builder'
-import type { Task } from 'domain/task/entity/task'
-import type { CreateTask } from 'domain/task/command/createTask'
+import type { Task, UpdateTask } from 'domain/task/entity/task'
+import type { AmendTask, CreateTask } from 'domain/task/command/createTask'
 import type { DeepReadonly } from 'superTypes'
+import { UpdateTaskBuilder } from 'domain/task/builder/updateTask/updateTask.builder'
 
 export class TaskMapper {
-  public static readonly mapCommandPayloadToEntity = (payload: DeepReadonly<CreateTask>): Task =>
+  public static readonly mapCreateTaskToEntity = (payload: DeepReadonly<CreateTask>): Task =>
     new TaskBuilder()
       .withId(payload.id)
       .withCreationDate(payload.timestamp)
@@ -14,4 +15,12 @@ export class TaskMapper {
       .withType(payload.type)
       .withStatus(payload.status)
       .build()
+
+  public static readonly mapAmendTaskToEntity = (payload: DeepReadonly<AmendTask>): UpdateTask => {
+    // eslint-disable-next-line functional/no-let
+    let builder = new UpdateTaskBuilder().withId(payload.id).withLastUpdateDate(payload.timestamp)
+    if (payload.messageKey) builder = builder.withMessageKey(payload.messageKey)
+    if (payload.status) builder = builder.withStatus(payload.status)
+    return builder.build()
+  }
 }

--- a/src/adapters/task/mapper/task.mapper.ts
+++ b/src/adapters/task/mapper/task.mapper.ts
@@ -1,3 +1,4 @@
+/* eslint-disable functional/no-let */
 import { TaskBuilder } from 'domain/task/builder/task/task.builder'
 import type { Task, UpdateTask } from 'domain/task/entity/task'
 import type { AmendTask, CreateTask } from 'domain/task/command/createTask'
@@ -5,19 +6,19 @@ import type { DeepReadonly } from 'superTypes'
 import { UpdateTaskBuilder } from 'domain/task/builder/updateTask/updateTask.builder'
 
 export class TaskMapper {
-  public static readonly mapCreateTaskToEntity = (payload: DeepReadonly<CreateTask>): Task =>
-    new TaskBuilder()
+  public static readonly mapCreateTaskToEntity = (payload: DeepReadonly<CreateTask>): Task => {
+    let builder = new TaskBuilder()
       .withId(payload.id)
       .withCreationDate(payload.timestamp)
       .withLastUpdateDate(payload.timestamp)
-      .withInitiator(payload.initiator)
       .withMessageKey(payload.messageKey)
       .withType(payload.type)
       .withStatus(payload.status)
-      .build()
+    if (payload.initiator) builder = builder.withInitiator(payload.initiator)
+    return builder.build()
+  }
 
   public static readonly mapAmendTaskToEntity = (payload: DeepReadonly<AmendTask>): UpdateTask => {
-    // eslint-disable-next-line functional/no-let
     let builder = new UpdateTaskBuilder().withId(payload.id).withLastUpdateDate(payload.timestamp)
     if (payload.messageKey) builder = builder.withMessageKey(payload.messageKey)
     if (payload.status) builder = builder.withStatus(payload.status)

--- a/src/adapters/task/primary/eventListeners.spec.ts
+++ b/src/adapters/task/primary/eventListeners.spec.ts
@@ -9,7 +9,8 @@ import type { EventMetadata } from 'eventBus/eventBus'
 import type { Task, TaskStatus } from 'domain/task/entity/task'
 import { UpdateTaskBuilder } from 'domain/task/builder/updateTask/updateTask.builder'
 import { TaskStoreBuilder } from 'domain/task/store/builder/store.builder'
-import { AmendTask, CreateTask } from 'domain/task/command/createTask'
+import { AmendTask } from 'domain/task/command/amendtask'
+import { CreateTask } from 'domain/task/command/createTask'
 
 type InitialProps = Readonly<{
   store: ReduxStore

--- a/src/adapters/task/primary/eventListeners.spec.ts
+++ b/src/adapters/task/primary/eventListeners.spec.ts
@@ -9,6 +9,7 @@ import type { EventMetadata } from 'eventBus/eventBus'
 import type { Task } from 'domain/task/entity/task'
 import { UpdateTaskBuilder } from 'domain/task/builder/updateTask/updateTask.builder'
 import { TaskStoreBuilder } from 'domain/task/store/builder/store.builder'
+import { CreateTask } from 'domain/task/command/createTask'
 
 type InitialProps = Readonly<{
   store: ReduxStore
@@ -23,24 +24,44 @@ type Data = DeepReadonly<{
 const aDate = new Date()
 const bDate = new Date()
 
+// Command payloads
+const rawTask1: CreateTask = {
+  id: 'id1',
+  timestamp: aDate,
+  type: 'task-test',
+  status: 'processing',
+  messageKey: 'domain.task.processing'
+}
+
+const rawTask2: CreateTask = {
+  id: 'id2',
+  timestamp: aDate,
+  type: 'task-test',
+  status: 'processing',
+  messageKey: 'domain.task.processing'
+}
+
+const meta: EventMetadata = { initiator: 'domain:test', timestamp: new Date() }
+
+// Entities
 const task1 = new TaskBuilder()
-  .withId('id1')
-  .withCreationDate(aDate)
-  .withLastUpdateDate(aDate)
-  .withMessageKey('domain.task.processing')
-  .withType('task-test')
-  .withStatus('processing')
-  .withInitiator('domain:test')
+  .withId(rawTask1.id)
+  .withCreationDate(rawTask1.timestamp)
+  .withLastUpdateDate(rawTask1.timestamp)
+  .withMessageKey(rawTask1.messageKey)
+  .withType(rawTask1.type)
+  .withStatus(rawTask1.status)
+  .withInitiator(meta.initiator)
   .build()
 
 const task2 = new TaskBuilder()
-  .withId('id2')
-  .withCreationDate(aDate)
-  .withLastUpdateDate(aDate)
-  .withMessageKey('domain.task.processing')
-  .withType('task-test')
-  .withStatus('processing')
-  .withInitiator('domain:test')
+  .withId(rawTask2.id)
+  .withCreationDate(rawTask2.timestamp)
+  .withLastUpdateDate(rawTask2.timestamp)
+  .withMessageKey(rawTask2.messageKey)
+  .withType(rawTask2.type)
+  .withStatus(rawTask2.status)
+  .withInitiator(meta.initiator)
   .build()
 
 const updatedTask = new UpdateTaskBuilder()
@@ -50,7 +71,6 @@ const updatedTask = new UpdateTaskBuilder()
   .withStatus('success')
   .build()
 
-const meta: EventMetadata = { initiator: 'domain:test', timestamp: new Date() }
 const initialState: AppState = {
   task: {
     byId: OrderedMap<string, Task>().set(task1.id, task1),
@@ -79,8 +99,8 @@ const getExpectedState = (
 describe.each`
   event                                                 | expectedState
   ${undefined}                                          | ${getExpectedState(initialState.task, initialState.displayedTaskIds)}
-  ${{ type: 'task/fooBar', payload: task2 }}            | ${getExpectedState(initialState.task, initialState.displayedTaskIds)}
-  ${{ type: 'task/taskCreated', payload: task2 }}       | ${getExpectedState({ byId: initialState.task.byId.set(task2.id, task2), byType: initialState.task.byType.set(task2.type, initialState.task.byType.get(task2.type, OrderedSet<string>()).add(task2.id)) }, initialState.displayedTaskIds.add(task2.id))}
+  ${{ type: 'task/fooBar', payload: rawTask1 }}         | ${getExpectedState(initialState.task, initialState.displayedTaskIds)}
+  ${{ type: 'task/taskCreated', payload: rawTask2 }}    | ${getExpectedState({ byId: initialState.task.byId.set(task2.id, task2), byType: initialState.task.byType.set(task2.type, initialState.task.byType.get(task2.type, OrderedSet<string>()).add(task2.id)) }, initialState.displayedTaskIds.add(task2.id))}
   ${{ type: 'task/taskAmended', payload: updatedTask }} | ${getExpectedState({ byId: initialState.task.byId.set(task1.id, { ...task1, ...updatedTask }), byType: initialState.task.byType }, initialState.displayedTaskIds)}
 `('Given that event is <$event>', ({ event, expectedState }: Data): void => {
   const { store, eventBus }: InitialProps = init()

--- a/src/domain/common/actionCreators.ts
+++ b/src/domain/common/actionCreators.ts
@@ -4,14 +4,15 @@ import type { ActionsUnion } from 'domain/common/store.helper'
 import { createAction } from 'domain/common/store.helper'
 import type { TypedBusEvent } from 'eventBus/eventBus'
 import type { DeepReadonly } from 'superTypes'
-import type { Task, UpdateTask } from 'domain/task/entity/task'
+import type { UpdateTask } from 'domain/task/entity/task'
+import type { CreateTask } from 'domain/task/command/createTask'
 
 export const ThrowErrorActions = {
   errorThrown: (error: Error) => createAction('error/errorThrown', error)
 }
 
 export const TaskActions = {
-  taskCreated: (task: Task) => createAction('task/taskCreated', task),
+  taskCreated: (task: DeepReadonly<CreateTask>) => createAction('task/taskCreated', task),
   taskAmended: (task: UpdateTask) => createAction('task/taskAmended', task)
 }
 

--- a/src/domain/common/actionCreators.ts
+++ b/src/domain/common/actionCreators.ts
@@ -4,8 +4,7 @@ import type { ActionsUnion } from 'domain/common/store.helper'
 import { createAction } from 'domain/common/store.helper'
 import type { TypedBusEvent } from 'eventBus/eventBus'
 import type { DeepReadonly } from 'superTypes'
-import type { UpdateTask } from 'domain/task/entity/task'
-import type { CreateTask } from 'domain/task/command/createTask'
+import type { CreateTask, AmendTask } from 'domain/task/command/createTask'
 
 export const ThrowErrorActions = {
   errorThrown: (error: Error) => createAction('error/errorThrown', error)
@@ -13,7 +12,7 @@ export const ThrowErrorActions = {
 
 export const TaskActions = {
   taskCreated: (task: DeepReadonly<CreateTask>) => createAction('task/taskCreated', task),
-  taskAmended: (task: UpdateTask) => createAction('task/taskAmended', task)
+  taskAmended: (task: DeepReadonly<AmendTask>) => createAction('task/taskAmended', task)
 }
 
 export type ThrowErrorActionTypes = ActionsUnion<typeof ThrowErrorActions>

--- a/src/domain/common/actionCreators.ts
+++ b/src/domain/common/actionCreators.ts
@@ -4,7 +4,8 @@ import type { ActionsUnion } from 'domain/common/store.helper'
 import { createAction } from 'domain/common/store.helper'
 import type { TypedBusEvent } from 'eventBus/eventBus'
 import type { DeepReadonly } from 'superTypes'
-import type { CreateTask, AmendTask } from 'domain/task/command/createTask'
+import type { AmendTask } from 'domain/task/command/amendtask'
+import type { CreateTask } from 'domain/task/command/createTask'
 
 export const ThrowErrorActions = {
   errorThrown: (error: Error) => createAction('error/errorThrown', error)

--- a/src/domain/faucet/usecase/request-funds/requestFunds.spec.ts
+++ b/src/domain/faucet/usecase/request-funds/requestFunds.spec.ts
@@ -7,7 +7,8 @@ import { EventParameter, getExpectedEventParameter } from 'domain/task/helper/te
 import { requestFunds, faucetTaskType } from './requestFunds'
 import { DeepReadonly } from 'superTypes'
 import { FaucetStoreBuilder } from 'domain/faucet/store/builder/store.builder'
-import { AmendTask, CreateTask } from 'domain/task/command/createTask'
+import { AmendTask } from 'domain/task/command/amendtask'
+import { CreateTask } from 'domain/task/command/createTask'
 
 interface InitialProps {
   store: ReduxStore

--- a/src/domain/faucet/usecase/request-funds/requestFunds.spec.ts
+++ b/src/domain/faucet/usecase/request-funds/requestFunds.spec.ts
@@ -9,6 +9,7 @@ import { requestFunds, faucetTaskType } from './requestFunds'
 import { DeepReadonly } from 'superTypes'
 import { UpdateTaskBuilder } from 'domain/task/builder/updateTask/updateTask.builder'
 import { FaucetStoreBuilder } from 'domain/faucet/store/builder/store.builder'
+import { CreateTask } from 'domain/task/command/createTask'
 
 interface InitialProps {
   store: ReduxStore
@@ -31,13 +32,13 @@ jest.setSystemTime(fakedDate)
 short.generate = jest.fn(() => fakedUuid as short.SUUID)
 const mockedEventBusPublish = jest.spyOn(eventBus, 'publish')
 
-const task = new TaskBuilder()
-  .withId(fakedUuid)
-  .withCreationDate(fakedDate)
-  .withLastUpdateDate(fakedDate)
-  .withMessageKey('domain.task.proceeded')
-  .withType(faucetTaskType)
-  .build()
+const task: CreateTask = {
+  id: fakedUuid,
+  timestamp: fakedDate,
+  status: 'processing',
+  messageKey: 'domain.task.proceeded',
+  type: faucetTaskType
+}
 
 const updatedTask1 = new UpdateTaskBuilder()
   .withId(fakedUuid)

--- a/src/domain/faucet/usecase/request-funds/requestFunds.ts
+++ b/src/domain/faucet/usecase/request-funds/requestFunds.ts
@@ -1,7 +1,8 @@
 import { ThrowErrorActions, TaskActions } from 'domain/common/actionCreators'
 import { ErrorMapper } from 'domain/error/mapper/error.mapper'
 import type { ReduxStore, ThunkResult } from 'domain/faucet/store/store'
-import type { AmendTask, CreateTask } from 'domain/task/command/createTask'
+import type { AmendTask } from 'domain/task/command/amendtask'
+import type { CreateTask } from 'domain/task/command/createTask'
 import short from 'short-uuid'
 import { checkOKP4Address } from '../../service/checkOKP4Address'
 

--- a/src/domain/faucet/usecase/request-funds/requestFunds.ts
+++ b/src/domain/faucet/usecase/request-funds/requestFunds.ts
@@ -1,8 +1,7 @@
 import { ThrowErrorActions, TaskActions } from 'domain/common/actionCreators'
 import { ErrorMapper } from 'domain/error/mapper/error.mapper'
 import type { ReduxStore, ThunkResult } from 'domain/faucet/store/store'
-import { UpdateTaskBuilder } from 'domain/task/builder/updateTask/updateTask.builder'
-import type { CreateTask } from 'domain/task/command/createTask'
+import type { AmendTask, CreateTask } from 'domain/task/command/createTask'
 import short from 'short-uuid'
 import { checkOKP4Address } from '../../service/checkOKP4Address'
 
@@ -21,12 +20,13 @@ const dispatchRequestFundsAmendedTask = (
   taskId: string,
   hasError?: boolean
 ): void => {
-  const updatedTask = new UpdateTaskBuilder()
-    .withId(taskId)
-    .withMessageKey(`domain.task.${hasError ? 'error' : 'success'}`)
-    .withStatus(hasError ? 'error' : 'success')
-    .build()
-  dispatch(TaskActions.taskAmended(updatedTask))
+  const updateTask: AmendTask = {
+    id: taskId,
+    messageKey: `domain.task.${hasError ? 'error' : 'success'}`,
+    timestamp: new Date(),
+    status: hasError ? 'error' : 'success'
+  }
+  dispatch(TaskActions.taskAmended(updateTask))
 }
 
 const dispatchRequestFundsError = (

--- a/src/domain/faucet/usecase/request-funds/requestFunds.ts
+++ b/src/domain/faucet/usecase/request-funds/requestFunds.ts
@@ -1,14 +1,20 @@
 import { ThrowErrorActions, TaskActions } from 'domain/common/actionCreators'
 import { ErrorMapper } from 'domain/error/mapper/error.mapper'
 import type { ReduxStore, ThunkResult } from 'domain/faucet/store/store'
-import { TaskBuilder } from 'domain/task/builder/task/task.builder'
 import { UpdateTaskBuilder } from 'domain/task/builder/updateTask/updateTask.builder'
+import type { CreateTask } from 'domain/task/command/createTask'
+import short from 'short-uuid'
 import { checkOKP4Address } from '../../service/checkOKP4Address'
 
 export const faucetTaskType = 'faucet#request-funds'
 
-const createTaskFactory = (): TaskBuilder =>
-  new TaskBuilder().withMessageKey('domain.task.proceeded').withType(faucetTaskType)
+const createTaskFactory = (): CreateTask => ({
+  id: short.generate(),
+  messageKey: 'domain.task.proceeded',
+  timestamp: new Date(),
+  type: faucetTaskType,
+  status: 'processing'
+})
 
 const dispatchRequestFundsAmendedTask = (
   dispatch: ReduxStore['dispatch'],
@@ -37,7 +43,7 @@ export const requestFunds =
   (address: string): ThunkResult<Promise<void>> =>
   // eslint-disable-next-line @typescript-eslint/typedef
   async (dispatch, _getState, { faucetGateway }) => {
-    const createTask = createTaskFactory().build()
+    const createTask = createTaskFactory()
     try {
       dispatch(TaskActions.taskCreated(createTask))
       checkOKP4Address(address)

--- a/src/domain/file/usecase/store-files/storeFiles.spec.ts
+++ b/src/domain/file/usecase/store-files/storeFiles.spec.ts
@@ -10,7 +10,7 @@ import { FileStoreBuilder } from 'domain/file/store/builder/store.builder'
 import { StoreFilePayload } from 'domain/file/command/storeFile'
 
 type Data = {
-  files: FileEntity[]
+  files: StoreFilePayload[]
   preloadedState: AppState
   expectedState: AppState
 }

--- a/src/domain/task/builder/task/task.builder.spec.ts
+++ b/src/domain/task/builder/task/task.builder.spec.ts
@@ -67,7 +67,7 @@ describe('Build a task', () => {
       describe('When building a task', () => {
         const task = (): Task => {
           // eslint-disable-next-line functional/no-let
-          let taskBuilder = new TaskBuilder(initialTask).withInitiator(initiator)
+          let taskBuilder = new TaskBuilder(initialTask)
 
           if (id !== undefined) {
             taskBuilder = taskBuilder.withId(id)
@@ -83,6 +83,9 @@ describe('Build a task', () => {
           }
           if (type !== undefined) {
             taskBuilder = taskBuilder.withType(type)
+          }
+          if (initiator !== undefined) {
+            taskBuilder = taskBuilder.withInitiator(initiator)
           }
           if (status !== undefined) {
             taskBuilder = taskBuilder.withStatus(status)

--- a/src/domain/task/builder/task/task.builder.spec.ts
+++ b/src/domain/task/builder/task/task.builder.spec.ts
@@ -36,20 +36,21 @@ describe('Build a task', () => {
   })
 
   describe.each`
-    initialTask           | id           | creationDate | lastUpdateDate | messageKey                  | type           | initiator | status          | expectedStatus
-    ${undefined}          | ${'#id1'}    | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${'test'} | ${'processing'} | ${true}
-    ${undefined}          | ${'#id2'}    | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${'test'} | ${undefined}    | ${true}
-    ${undefined}          | ${'#id3'}    | ${aDate}     | ${undefined}   | ${'domain.task.processing'} | ${'test-task'} | ${'test'} | ${'processing'} | ${true}
-    ${undefined}          | ${undefined} | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${'test'} | ${'processing'} | ${true}
-    ${undefined}          | ${'#id5'}    | ${undefined} | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${'test'} | ${'processing'} | ${true}
-    ${undefined}          | ${''}        | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${'test'} | ${'processing'} | ${false}
-    ${undefined}          | ${'#id7'}    | ${aDate}     | ${aDate}       | ${''}                       | ${'test-task'} | ${'test'} | ${'processing'} | ${false}
-    ${undefined}          | ${'#id8'}    | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${''}          | ${'test'} | ${'processing'} | ${false}
-    ${{ messageKey: '' }} | ${'#id8'}    | ${undefined} | ${aDate}       | ${undefined}                | ${undefined}   | ${'test'} | ${'processing'} | ${false}
-    ${undefined}          | ${'#id8'}    | ${aBadDate}  | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${'test'} | ${'processing'} | ${false}
-    ${undefined}          | ${'#id8'}    | ${aDate}     | ${aBadDate}    | ${'domain.task.processing'} | ${'test-task'} | ${'test'} | ${'processing'} | ${false}
-    ${undefined}          | ${'#id8'}    | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${''}     | ${'processing'} | ${false}
-    ${undefined}          | ${'#id8'}    | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${'test'} | ${''}           | ${false}
+    initialTask           | id           | creationDate | lastUpdateDate | messageKey                  | type           | initiator    | status          | expectedStatus
+    ${undefined}          | ${'#id1'}    | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${'test'}    | ${'processing'} | ${true}
+    ${undefined}          | ${'#id1'}    | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${undefined} | ${'processing'} | ${true}
+    ${undefined}          | ${'#id2'}    | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${'test'}    | ${undefined}    | ${true}
+    ${undefined}          | ${'#id3'}    | ${aDate}     | ${undefined}   | ${'domain.task.processing'} | ${'test-task'} | ${'test'}    | ${'processing'} | ${true}
+    ${undefined}          | ${undefined} | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${'test'}    | ${'processing'} | ${true}
+    ${undefined}          | ${'#id5'}    | ${undefined} | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${'test'}    | ${'processing'} | ${true}
+    ${undefined}          | ${''}        | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${'test'}    | ${'processing'} | ${false}
+    ${undefined}          | ${'#id7'}    | ${aDate}     | ${aDate}       | ${''}                       | ${'test-task'} | ${'test'}    | ${'processing'} | ${false}
+    ${undefined}          | ${'#id8'}    | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${''}          | ${'test'}    | ${'processing'} | ${false}
+    ${{ messageKey: '' }} | ${'#id8'}    | ${undefined} | ${aDate}       | ${undefined}                | ${undefined}   | ${'test'}    | ${'processing'} | ${false}
+    ${undefined}          | ${'#id8'}    | ${aBadDate}  | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${'test'}    | ${'processing'} | ${false}
+    ${undefined}          | ${'#id8'}    | ${aDate}     | ${aBadDate}    | ${'domain.task.processing'} | ${'test-task'} | ${'test'}    | ${'processing'} | ${false}
+    ${undefined}          | ${'#id8'}    | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${''}        | ${'processing'} | ${false}
+    ${undefined}          | ${'#id8'}    | ${aDate}     | ${aDate}       | ${'domain.task.processing'} | ${'test-task'} | ${'test'}    | ${''}           | ${false}
   `(
     'Given that id is <$id>, creationDate is <$creationDate>, lastUpdateDate is <$lastUpdateDate>, messageKey is <$messageKey>, type is <$type>, initiator is <$initiator> and status is <$status>',
     ({
@@ -66,7 +67,7 @@ describe('Build a task', () => {
       describe('When building a task', () => {
         const task = (): Task => {
           // eslint-disable-next-line functional/no-let
-          let taskBuilder = new TaskBuilder(initialTask)
+          let taskBuilder = new TaskBuilder(initialTask).withInitiator(initiator)
 
           if (id !== undefined) {
             taskBuilder = taskBuilder.withId(id)
@@ -82,9 +83,6 @@ describe('Build a task', () => {
           }
           if (type !== undefined) {
             taskBuilder = taskBuilder.withType(type)
-          }
-          if (initiator !== undefined) {
-            taskBuilder = taskBuilder.withInitiator(initiator)
           }
           if (status !== undefined) {
             taskBuilder = taskBuilder.withStatus(status)

--- a/src/domain/task/builder/task/task.builder.ts
+++ b/src/domain/task/builder/task/task.builder.ts
@@ -64,10 +64,7 @@ export class TaskBuilder {
     return new TaskBuilder({ ...this.task, status })
   }
 
-  public withInitiator(initiator?: string): TaskBuilder {
-    if (initiator === undefined) {
-      return this
-    }
+  public withInitiator(initiator: string): TaskBuilder {
     if (!initiator.length) {
       throw new UnspecifiedError('Oops... An initiator must be provided to build a task...')
     }

--- a/src/domain/task/builder/task/task.builder.ts
+++ b/src/domain/task/builder/task/task.builder.ts
@@ -64,7 +64,10 @@ export class TaskBuilder {
     return new TaskBuilder({ ...this.task, status })
   }
 
-  public withInitiator(initiator: string): TaskBuilder {
+  public withInitiator(initiator?: string): TaskBuilder {
+    if (initiator === undefined) {
+      return this
+    }
     if (!initiator.length) {
       throw new UnspecifiedError('Oops... An initiator must be provided to build a task...')
     }

--- a/src/domain/task/command/amendtask.ts
+++ b/src/domain/task/command/amendtask.ts
@@ -1,0 +1,8 @@
+import type { TaskStatus } from '../entity/task'
+
+export type AmendTask<I = string> = {
+  readonly id: I
+  readonly timestamp: Date
+  readonly status?: TaskStatus
+  readonly messageKey?: string
+}

--- a/src/domain/task/command/createTask.ts
+++ b/src/domain/task/command/createTask.ts
@@ -8,10 +8,3 @@ export type CreateTask<I = string, T = string> = {
   readonly messageKey: string
   readonly initiator?: string
 }
-
-export type AmendTask<I = string> = {
-  readonly id: I
-  readonly timestamp: Date
-  readonly status?: TaskStatus
-  readonly messageKey?: string
-}

--- a/src/domain/task/command/createTask.ts
+++ b/src/domain/task/command/createTask.ts
@@ -8,3 +8,10 @@ export type CreateTask<I = string, T = string> = {
   readonly messageKey: string
   readonly initiator?: string
 }
+
+export type AmendTask<I = string> = {
+  readonly id: I
+  readonly timestamp: Date
+  readonly status?: TaskStatus
+  readonly messageKey?: string
+}

--- a/src/domain/task/command/createTask.ts
+++ b/src/domain/task/command/createTask.ts
@@ -1,0 +1,10 @@
+import type { TaskStatus } from '../entity/task'
+
+export type CreateTask<I = string, T = string> = {
+  readonly id: I
+  readonly timestamp: Date
+  readonly type: T
+  readonly status: TaskStatus
+  readonly messageKey: string
+  readonly initiator?: string
+}

--- a/src/domain/task/helper/test.helper.ts
+++ b/src/domain/task/helper/test.helper.ts
@@ -1,20 +1,16 @@
 import type { Error } from 'domain/error/entity/error'
 import type { EventMetadata } from 'eventBus/eventBus'
 import type { Pair } from 'superTypes'
-import type { Task, UpdateTask } from '../entity/task'
 
-export type EventParameter = Pair<
-  { type: string; payload: Error | Task | UpdateTask },
-  EventMetadata
->
-type Payload = Error | Task | UpdateTask
+export type EventParameter<T> = Pair<{ type: string; payload: Payload<T> }, EventMetadata>
+type Payload<T> = Error | T
 
-export const getExpectedEventParameter = (
+export const getExpectedEventParameter = <T>(
   type: string,
-  payload: Payload,
+  payload: Payload<T>,
   initiator: string,
   date: Readonly<Date>
-): EventParameter => {
+): EventParameter<T> => {
   return [
     { ...{ type }, ...{ payload } },
     { initiator, timestamp: date }

--- a/src/domain/task/usecase/register-task/registerTask.spec.ts
+++ b/src/domain/task/usecase/register-task/registerTask.spec.ts
@@ -20,7 +20,7 @@ type InitialProps = Readonly<{
 type Data = {
   tasks: CreateTask[]
   expectedState: AppState
-  expectedEventParameters: EventParameter[]
+  expectedEventParameters: EventParameter<Task>[]
 }
 
 const eventBus = new EventBus()
@@ -138,10 +138,12 @@ describe('Register a task', () => {
           })
           expect(store.getState()).toStrictEqual(expectedState)
           if (expectedEventParameters.length) {
-            expectedEventParameters.forEach((elt: DeepReadonly<EventParameter>, index: number) => {
-              const [first, second]: Readonly<EventParameter> = elt
-              expect(mockedEventBusPublish).toHaveBeenNthCalledWith(index + 1, first, second)
-            })
+            expectedEventParameters.forEach(
+              (elt: DeepReadonly<EventParameter<Task>>, index: number) => {
+                const [first, second]: Readonly<EventParameter<Task>> = elt
+                expect(mockedEventBusPublish).toHaveBeenNthCalledWith(index + 1, first, second)
+              }
+            )
           }
         })
       })

--- a/src/domain/task/usecase/register-task/registerTask.spec.ts
+++ b/src/domain/task/usecase/register-task/registerTask.spec.ts
@@ -87,7 +87,7 @@ describe('Register a task', () => {
     .withMessageKey(rawTask1.messageKey)
     .withType(rawTask1.type)
     .withStatus(rawTask1.status)
-    .withInitiator(rawTask1.initiator)
+    .withInitiator(rawTask1.initiator as string)
     .build()
 
   const task2 = new TaskBuilder()
@@ -97,7 +97,7 @@ describe('Register a task', () => {
     .withMessageKey(rawTask2.messageKey)
     .withType(rawTask2.type)
     .withStatus(rawTask2.status)
-    .withInitiator(rawTask2.initiator)
+    .withInitiator(rawTask2.initiator as string)
     .build()
 
   const error = new ErrorBuilder()

--- a/src/domain/task/usecase/register-task/registerTask.ts
+++ b/src/domain/task/usecase/register-task/registerTask.ts
@@ -1,9 +1,11 @@
 import type { ReduxStore, ThunkResult } from 'domain/task/store/store'
-import type { Task } from 'domain/task/entity/task'
 import { RegisterTaskActions } from './actionCreators'
 import { ThrowErrorActions } from 'domain/common/actionCreators'
 import { ErrorMapper } from 'domain/error/mapper/error.mapper'
 import { UnspecifiedError } from 'domain/task/entity/error'
+import type { CreateTask } from 'domain/task/command/createTask'
+import { TaskMapper } from 'adapters/task/mapper/task.mapper'
+import type { DeepReadonly } from 'superTypes'
 
 const dispatchError = (error: unknown, dispatch: ReduxStore['dispatch']): void => {
   const errorToDispatch = ErrorMapper.mapRawErrorToEntity(error)
@@ -11,7 +13,7 @@ const dispatchError = (error: unknown, dispatch: ReduxStore['dispatch']): void =
 }
 
 export const registerTask =
-  (task: Task): ThunkResult<Promise<void>> =>
+  (task: DeepReadonly<CreateTask>): ThunkResult<Promise<void>> =>
   // eslint-disable-next-line @typescript-eslint/typedef
   async (dispatch, getState) => {
     if (getState().task.byId.has(task.id)) {
@@ -23,5 +25,5 @@ export const registerTask =
       )
       return
     }
-    dispatch(RegisterTaskActions.taskRegistered(task))
+    dispatch(RegisterTaskActions.taskRegistered(TaskMapper.mapCommandPayloadToEntity(task)))
   }

--- a/src/domain/task/usecase/register-task/registerTask.ts
+++ b/src/domain/task/usecase/register-task/registerTask.ts
@@ -25,5 +25,5 @@ export const registerTask =
       )
       return
     }
-    dispatch(RegisterTaskActions.taskRegistered(TaskMapper.mapCommandPayloadToEntity(task)))
+    dispatch(RegisterTaskActions.taskRegistered(TaskMapper.mapCreateTaskToEntity(task)))
   }

--- a/src/domain/task/usecase/update-task/updateTask.spec.ts
+++ b/src/domain/task/usecase/update-task/updateTask.spec.ts
@@ -12,7 +12,7 @@ import type { EventParameter } from '../../helper/test.helper'
 import { getExpectedEventParameter } from '../../helper/test.helper'
 import { UpdateTaskBuilder } from 'domain/task/builder/updateTask/updateTask.builder'
 import { TaskStoreBuilder } from 'domain/task/store/builder/store.builder'
-import { AmendTask } from 'domain/task/command/createTask'
+import { AmendTask } from 'domain/task/command/amendtask'
 
 type Data = {
   state: AppState

--- a/src/domain/task/usecase/update-task/updateTask.spec.ts
+++ b/src/domain/task/usecase/update-task/updateTask.spec.ts
@@ -18,7 +18,7 @@ type Data = {
   state: AppState
   updatedTask: AmendTask[]
   expectedState: AppState
-  expectedEventParameters: EventParameter[]
+  expectedEventParameters: EventParameter<UpdateTask>[]
 }
 
 const eventBus = new EventBus()
@@ -159,10 +159,12 @@ describe('Update a task', () => {
           })
           expect(store.getState()).toStrictEqual(expectedState)
           if (expectedEventParameters.length) {
-            expectedEventParameters.forEach((elt: DeepReadonly<EventParameter>, index: number) => {
-              const [first, second]: Readonly<EventParameter> = elt
-              expect(mockedEventBusPublish).toHaveBeenNthCalledWith(index + 1, first, second)
-            })
+            expectedEventParameters.forEach(
+              (elt: DeepReadonly<EventParameter<UpdateTask>>, index: number) => {
+                const [first, second]: Readonly<EventParameter<UpdateTask>> = elt
+                expect(mockedEventBusPublish).toHaveBeenNthCalledWith(index + 1, first, second)
+              }
+            )
           }
         })
       })

--- a/src/domain/task/usecase/update-task/updateTask.ts
+++ b/src/domain/task/usecase/update-task/updateTask.ts
@@ -1,9 +1,11 @@
 import type { ReduxStore, ThunkResult } from 'domain/task/store/store'
-import type { UpdateTask } from 'domain/task/entity/task'
 import { UpdateTaskActions } from './actionCreators'
 import { ThrowErrorActions } from 'domain/common/actionCreators'
 import { ErrorMapper } from 'domain/error/mapper/error.mapper'
 import { UnspecifiedError } from 'domain/task/entity/error'
+import type { AmendTask } from 'domain/task/command/createTask'
+import type { DeepReadonly } from 'superTypes'
+import { TaskMapper } from 'adapters/task/mapper/task.mapper'
 
 const dispatchError = (error: unknown, dispatch: ReduxStore['dispatch']): void => {
   const errorToDispatch = ErrorMapper.mapRawErrorToEntity(error)
@@ -11,7 +13,7 @@ const dispatchError = (error: unknown, dispatch: ReduxStore['dispatch']): void =
 }
 
 export const updateTask =
-  (task: UpdateTask): ThunkResult<Promise<void>> =>
+  (task: DeepReadonly<AmendTask>): ThunkResult<Promise<void>> =>
   // eslint-disable-next-line @typescript-eslint/typedef
   async (dispatch, getState) => {
     if (!getState().task.byId.has(task.id)) {
@@ -23,5 +25,5 @@ export const updateTask =
       )
       return
     }
-    dispatch(UpdateTaskActions.taskUpdated(task))
+    dispatch(UpdateTaskActions.taskUpdated(TaskMapper.mapAmendTaskToEntity(task)))
   }

--- a/src/domain/task/usecase/update-task/updateTask.ts
+++ b/src/domain/task/usecase/update-task/updateTask.ts
@@ -3,7 +3,7 @@ import { UpdateTaskActions } from './actionCreators'
 import { ThrowErrorActions } from 'domain/common/actionCreators'
 import { ErrorMapper } from 'domain/error/mapper/error.mapper'
 import { UnspecifiedError } from 'domain/task/entity/error'
-import type { AmendTask } from 'domain/task/command/createTask'
+import type { AmendTask } from 'domain/task/command/amendtask'
 import type { DeepReadonly } from 'superTypes'
 import { TaskMapper } from 'adapters/task/mapper/task.mapper'
 


### PR DESCRIPTION
👉 This PR modifies the way commands are handled in the `task` domain.

😱 Indeed, in the previous version, the fundamental principle of protection of domain entities under hexagonal architecture was violated because the commands called by the primary controller (listener) directly manipulated the `task` or the `updateTask` entities as a parameter.

✅ For this, it is necessary to create a type of transfer dissociated from the entity as well as to add a mapping layer which will ensure that the entity is correctly constructed from the DTO.

😎 The `task` entity is thus not leaked to the controllers and the events only transport DTOs.