### PR TITLE
Docs/refactor icon story

### DIFF
--- a/stories/atoms/components/icon/icon.scss
+++ b/stories/atoms/components/icon/icon.scss
@@ -26,7 +26,7 @@
 
 .bg-arrow-right {
   @include with-theme() {
-    background: themed('primary-brand');
+    background: themed('border');
     border-radius: 10px;
   }
 }

--- a/stories/atoms/components/icon/icon.stories.mdx
+++ b/stories/atoms/components/icon/icon.stories.mdx
@@ -35,7 +35,7 @@ import './icon.scss'
 
 Icons help convey ideas to users in a quick and simple way,
 reducing the need for text that can be hard to read and less intuitive.  
-**Icon** has the following properties:
+Icon has the following properties:
 
 - `name` the name of the icon you want to use. All icons come in both light and dark theme.
 - `size` optional size property applied to both the width and height of the icon.
@@ -69,7 +69,9 @@ reducing the need for text that can be hard to read and less intuitive.
 ## Name
 
 The component has several icons to choose from and they are all themed. To use an icon you just have to pass
-the **name** of the icon you want as the property value.
+the name of the icon you want as the property value.
+
+Below you will find all available icons with their respective name.
 
 <Canvas>
   <Story name="Name">
@@ -126,7 +128,7 @@ the **name** of the icon you want as the property value.
 ## Size
 
 The `size` is squared and can be adjusted by passing a number value.  
-By `default` the size is **30** pixels.
+By default the size is **30** pixels.
 
 <Canvas>
   <Story name="Size">
@@ -159,7 +161,7 @@ By `default` the size is **30** pixels.
 
 ## Class Name
 
-The `className` property allows you to style the svg with css properties.  
+The `className` property allows you to style the icon with css properties.  
 As seen in the examples below you can rotate icons, add background colors, animate them and more!
 
 <Canvas>

--- a/stories/atoms/components/icon/icon.stories.mdx
+++ b/stories/atoms/components/icon/icon.stories.mdx
@@ -52,7 +52,6 @@ reducing the need for text that can be hard to read and less intuitive.
     <div
       style={{
         display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(30px,auto))',
         justifyContent: 'center'
       }}
     >
@@ -69,7 +68,7 @@ reducing the need for text that can be hard to read and less intuitive.
 
 ## Name
 
-The component has several icons to choose from and they are all thematized. To use an icon you pass
+The component has several icons to choose from and they are all themed. To use an icon you just have to pass
 the **name** of the icon you want as the property value.
 
 <Canvas>
@@ -126,7 +125,7 @@ the **name** of the icon you want as the property value.
 
 ## Size
 
-The **size** is squared and can be adjusted by passing a number value.  
+The `size` is squared and can be adjusted by passing a number value.  
 By `default` the size is **30** pixels.
 
 <Canvas>
@@ -160,7 +159,7 @@ By `default` the size is **30** pixels.
 
 ## Class Name
 
-The **className** property allows you to style the svg with css properties.  
+The `className` property allows you to style the svg with css properties.  
 As seen in the examples below you can rotate icons, add background colors, animate them and more!
 
 <Canvas>

--- a/stories/atoms/components/icon/icon.stories.mdx
+++ b/stories/atoms/components/icon/icon.stories.mdx
@@ -37,27 +37,33 @@ Icons help convey ideas to users in a quick and simple way,
 reducing the need for text that can be hard to read and less intuitive.  
 Icon has the following properties:
 
-- `name` the name of the icon you want to use. All icons come in both light and dark theme.
-- `size` optional size property applied to both the width and height of the icon.
-- `className` optional class name for custom css styling.
+- `name`: the name of the icon you want to use. All icons come in both light and dark theme.
+- `size`: optional size property applied to both the width and height of the icon.
+- `invertColor`: optional property to invert the icon color.
+- `className`: optional class name for custom CSS styling.
 
 ## Overview
 
 <Story
   name="Overview"
   argTypes={{ className: { control: false } }}
-  args={{ name: 'profile', size: 30 }}
+  args={{ name: 'profile', size: 30, invertColor: false }}
 >
-  {args => (
-    <div
-      style={{
-        display: 'grid',
-        justifyContent: 'center'
-      }}
-    >
-      <Icon {...args} />
-    </div>
-  )}
+  {args => {
+    const inverted = args.invertColor ? 'inverted' : ''
+    return (
+      <div
+        style={{
+          display: 'grid',
+          justifyContent: 'center'
+        }}
+      >
+        <div className={`icon-card ${inverted}`} style={{ width: '150px' }}>
+          <Icon {...args} />
+        </div>
+      </div>
+    )
+  }}
 </Story>
 
 ---
@@ -114,7 +120,7 @@ Below you will find all available icons with their respective name.
           {iconNames.map(icon => (
             <div className="icon-card" key={icon}>
               <Icon name={icon} />
-              <Typography as="span" fontSize="x-small" fontFamily="secondary">
+              <Typography fontSize="x-small" fontFamily="secondary">
                 {icon}
               </Typography>
             </div>
@@ -140,15 +146,14 @@ By default the size is **30** pixels.
             display: 'grid',
             gridTemplateColumns: 'repeat(auto-fit, minmax(75px,auto))',
             justifyContent: 'center',
-            justifyItems: 'center',
-            alignItems: 'center',
+            placeItems: 'center',
             gap: '10px'
           }}
         >
           {sizes.map(size => (
             <div className="icon-size" key={size}>
               <Icon name="wallet" size={size} />
-              <Typography as="span" fontSize="x-small" fontFamily="secondary">
+              <Typography fontSize="x-small" fontFamily="secondary">
                 {size}
               </Typography>
             </div>
@@ -159,31 +164,9 @@ By default the size is **30** pixels.
   </Story>
 </Canvas>
 
-## Class Name
-
-The `className` property allows you to style the icon with css properties.  
-As seen in the examples below you can rotate icons, add background colors, animate them and more!
-
-<Canvas>
-  <Story name="Class Name">
-    <div
-      style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(30px,auto))',
-        justifyContent: 'center',
-        gap: '30px'
-      }}
-    >
-      <Icon name="add" className="rotate-add" />
-      <Icon name="arrow-right" className="bg-arrow-right" />
-      <Icon name="chat" className="bouncing-chat" />
-    </div>
-  </Story>
-</Canvas>
-
 ## Invert color
 
-The `invertColor` property allows you to invert the color of the icon, regarding the current theme.  
+The `invertColor` property allows you to invert the themed color of the icon, by default this property is **false**.  
 If set to **true**, the icon will be displayed in **white** when the light theme is selected and in **blue** when the dark theme is active.
 In particular, this makes it possible to better manage high-contrast elements and thus offer the user an immersive User eXperience.
 
@@ -199,16 +182,38 @@ In particular, this makes it possible to better manage high-contrast elements an
     >
       <div className="icon-card">
         <Icon name="wallet" />
-        <Typography as="span" color="text" fontSize="x-small" fontFamily="secondary">
+        <Typography color="text" fontSize="x-small" fontFamily="secondary">
           Current theme
         </Typography>
       </div>
       <div className="icon-card inverted">
         <Icon name="wallet" invertColor />
-        <Typography as="span" color="inverted-text" fontSize="x-small" fontFamily="secondary">
+        <Typography color="inverted-text" fontSize="x-small" fontFamily="secondary">
           Inverse theme
         </Typography>
       </div>
+    </div>
+  </Story>
+</Canvas>
+
+## Class Name
+
+The `className` property allows you to style the icon with CSS properties.  
+As seen in the examples below you can rotate icons, add background colors, animate them and more!
+
+<Canvas>
+  <Story name="Class name">
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(30px,auto))',
+        justifyContent: 'center',
+        gap: '30px'
+      }}
+    >
+      <Icon name="add" className="rotate-add" />
+      <Icon name="arrow-right" className="bg-arrow-right" />
+      <Icon name="chat" className="bouncing-chat" />
     </div>
   </Story>
 </Canvas>


### PR DESCRIPTION
This PR implements #459 for `Icon`.

Recap of the most important changes:

- conformed descriptions to format (bold **values**, `properties` in bac tics, default values in story description).
- Removed redundant as="span" in `Typography` components.
- added default values in Overview story args to improve property table, as per [wiki](https://github.com/okp4/ui/wiki/Create-A-Story) specifications.
- added icon-card div for Overview component.
![Capture d’écran 2022-09-05 à 14 53 02](https://user-images.githubusercontent.com/75730728/188454098-456a1d41-f2c5-437b-986d-ad6fe6859b1d.png)
- Changed background color for icon component in class name story.
![Capture d’écran 2022-09-05 à 14 53 28](https://user-images.githubusercontent.com/75730728/188454094-3427af42-f30c-4d46-8f7f-3253c7fa486b.png)

