### PR TITLE
Add text decoration to Typography

### DIFF
--- a/src/ui/atoms/typography/Typography.tsx
+++ b/src/ui/atoms/typography/Typography.tsx
@@ -24,6 +24,10 @@ export type TypographyProps = DeepReadonly<{
    */
   readonly fontWeight?: 'xlight' | 'light' | 'bold' | 'black'
   /**
+   * The different text decoration.
+   */
+  readonly textDecoration?: 'underline'
+  /**
    * The color applied to the final rendering of the typography,
    * regarding the current theme and following semantic color naming.
    */
@@ -53,6 +57,7 @@ export const Typography: React.FC<TypographyProps> = ({
   noWrap = false,
   fontWeight = 'light',
   fontFamily = 'brand',
+  textDecoration,
   color = 'text',
   fontSize = 'medium',
   children,
@@ -61,7 +66,8 @@ export const Typography: React.FC<TypographyProps> = ({
   const typographyClass = classNames(`okp4-typography-main okp4-font-size-${fontSize}`, {
     [`text-color-${color}`]: true,
     'text-wrap-disabled': !!noWrap,
-    [`${fontFamily}-${fontWeight}`]: true
+    [`${fontFamily}-${fontWeight}`]: true,
+    underline: textDecoration === 'underline'
   })
   return React.createElement(as, { ...props, className: typographyClass }, children)
 }

--- a/src/ui/atoms/typography/Typography.tsx
+++ b/src/ui/atoms/typography/Typography.tsx
@@ -24,7 +24,7 @@ export type TypographyProps = DeepReadonly<{
    */
   readonly fontWeight?: 'xlight' | 'light' | 'bold' | 'black'
   /**
-   * The different text decoration.
+   * Sets the appearance of decorative lines on text.
    */
   readonly textDecoration?: 'underline'
   /**

--- a/src/ui/atoms/typography/typography.scss
+++ b/src/ui/atoms/typography/typography.scss
@@ -35,6 +35,10 @@ $weights: (
       }
     }
 
+    &.underline {
+      text-decoration: underline;
+    }
+
     @each $family in $families {
       @each $weight-key, $weight-value in $weights {
         &.#{$family}-#{$weight-key} {

--- a/stories/atoms/components/typography/Typography.stories.mdx
+++ b/stories/atoms/components/typography/Typography.stories.mdx
@@ -246,6 +246,25 @@ Internally, this parameter will actually select a variant of the selected font.
   </Story>
 </Canvas>
 
+## Text decoration
+
+It is possible to add a text decoration with the optional property `textDecoration`.  
+This property can take the following value :
+
+- **underline** : underlines the text in the same color as the text itself.
+
+There will be more text decoration as the library develops.
+
+<Canvas>
+  <Story name="Text decoration">
+    <div>
+      <Typography as="div" fontFamily="brand" fontSize="medium" textDecoration="underline">
+        underline | OKP4 - At the core of the stakes of data valorisation
+      </Typography>
+    </div>
+  </Story>
+</Canvas>
+
 ## Text-wrap
 
 By default, the element rendered will automatically wrap : newline characters in the source are handled the same as other white space. Lines are broken as necessary to fill line boxes.

--- a/stories/atoms/components/typography/Typography.stories.mdx
+++ b/stories/atoms/components/typography/Typography.stories.mdx
@@ -248,17 +248,17 @@ Internally, this parameter will actually select a variant of the selected font.
 
 ## Text decoration
 
-It is possible to add a text decoration with the optional property `textDecoration`.  
-This property can take the following value :
+The `textDecoration` property adds context to the Typography component and thus optimizes user actions.
+At the moment, the available value is:
 
 - **underline** : underlines the text in the same color as the text itself.
 
-There will be more text decoration as the library develops.
+More options are already under development and will make it possible to take even more advantage of this property.
 
 <Canvas>
   <Story name="Text decoration">
     <div>
-      <Typography as="div" fontFamily="brand" fontSize="medium" textDecoration="underline">
+      <Typography as="div" textDecoration="underline">
         underline | OKP4 - At the core of the stakes of data valorisation
       </Typography>
     </div>


### PR DESCRIPTION
This PR add the `textDecoration` property to `Typography` to allow underline a text.

<img width="728" alt="image" src="https://user-images.githubusercontent.com/107192362/187443192-3e4c645d-1dfb-4633-a4fa-6419ccd5d533.png">

👉 It refers to the issue https://github.com/okp4/ui/issues/485
