### PR TITLE
Docs/refactor story theme switches

### DIFF
--- a/stories/atoms/components/button/Button.stories.mdx
+++ b/stories/atoms/components/button/Button.stories.mdx
@@ -18,8 +18,10 @@ import { Icon } from 'ui/atoms/icon/Icon'
   decorators={[
     Story => (
       <ThemeProvider>
-        <div className="component-story-main">
+        <div className="story-theme-switcher">
           <ThemeSwitcher />
+        </div>
+        <div className="component-story-main">
           <Story />
         </div>
       </ThemeProvider>

--- a/stories/atoms/components/card/Card.stories.mdx
+++ b/stories/atoms/components/card/Card.stories.mdx
@@ -20,8 +20,10 @@ import { ThemeSwitcher } from 'ui/atoms/theme/ThemeSwitcher'
   decorators={[
     Story => (
       <ThemeProvider>
-        <div className="component-story-main">
+        <div className="story-theme-switcher">
           <ThemeSwitcher />
+        </div>
+        <div className="component-story-main">
           <Story />
         </div>
       </ThemeProvider>

--- a/stories/atoms/components/component.scss
+++ b/stories/atoms/components/component.scss
@@ -2,7 +2,7 @@
 
 .component-story-main {
   @include with-theme {
-    padding: 20px 30px 35px 30px;
+    padding: 40px;
     display: flex;
     flex-direction: column;
     gap: 20px;
@@ -16,4 +16,8 @@
       background: themed('inverted-field');
     }
   }
+}
+
+.story-theme-switcher {
+  padding: 5px 15px 13px;
 }

--- a/stories/atoms/components/fileInput/FileInput.stories.mdx
+++ b/stories/atoms/components/fileInput/FileInput.stories.mdx
@@ -21,8 +21,10 @@ import { useState } from 'react'
   decorators={[
     Story => (
       <ThemeProvider>
-        <div className="component-story-main">
+        <div className="story-theme-switcher">
           <ThemeSwitcher />
+        </div>
+        <div className="component-story-main">
           <div
             style={{
               padding: '10px 0',

--- a/stories/atoms/components/icon/icon.stories.mdx
+++ b/stories/atoms/components/icon/icon.stories.mdx
@@ -13,8 +13,10 @@ import './icon.scss'
     Story => {
       return (
         <ThemeProvider>
-          <div className="component-story-main">
+          <div className="story-theme-switcher">
             <ThemeSwitcher />
+          </div>
+          <div className="component-story-main">
             <Story />
           </div>
         </ThemeProvider>

--- a/stories/atoms/components/languageSwitcher/LanguageSwitcher.stories.mdx
+++ b/stories/atoms/components/languageSwitcher/LanguageSwitcher.stories.mdx
@@ -9,8 +9,10 @@ import { ThemeSwitcher } from 'ui/atoms/theme/ThemeSwitcher'
   decorators={[
     Story => (
       <ThemeProvider>
-        <div className="component-story-main language-switcher">
+        <div className="story-theme-switcher">
           <ThemeSwitcher />
+        </div>
+        <div className="component-story-main language-switcher">
           <Story />
         </div>
       </ThemeProvider>

--- a/stories/atoms/components/list/List.stories.mdx
+++ b/stories/atoms/components/list/List.stories.mdx
@@ -19,8 +19,10 @@ import { Icon } from 'ui/atoms/icon/Icon'
   decorators={[
     Story => (
       <ThemeProvider>
-        <div className="component-story-main">
+        <div className="story-theme-switcher">
           <ThemeSwitcher />
+        </div>
+        <div className="component-story-main">
           <div
             style={{
               display: 'grid',

--- a/stories/atoms/components/listItem/ListItem.stories.mdx
+++ b/stories/atoms/components/listItem/ListItem.stories.mdx
@@ -24,8 +24,10 @@ import { useState } from 'react'
   decorators={[
     Story => (
       <ThemeProvider>
-        <div className="component-story-main">
+        <div className="story-theme-switcher">
           <ThemeSwitcher />
+        </div>
+        <div className="component-story-main">
           <div
             style={{
               display: 'grid',

--- a/stories/atoms/components/logo/Logo.stories.mdx
+++ b/stories/atoms/components/logo/Logo.stories.mdx
@@ -14,8 +14,10 @@ import '../component.scss'
   decorators={[
     Story => (
       <ThemeProvider>
-        <div className="component-story-main">
+        <div className="story-theme-switcher">
           <ThemeSwitcher />
+        </div>
+        <div className="component-story-main">
           <Story />
         </div>
       </ThemeProvider>

--- a/stories/atoms/components/progressBar/ProgressBar.stories.mdx
+++ b/stories/atoms/components/progressBar/ProgressBar.stories.mdx
@@ -19,8 +19,10 @@ import { useState } from 'react'
   decorators={[
     Story => (
       <ThemeProvider>
-        <div className="component-story-main">
+        <div className="story-theme-switcher">
           <ThemeSwitcher />
+        </div>
+        <div className="component-story-main">
           <div
             style={{
               display: 'grid',

--- a/stories/atoms/components/textField/TextField.stories.mdx
+++ b/stories/atoms/components/textField/TextField.stories.mdx
@@ -22,8 +22,10 @@ import '../component.scss'
   decorators={[
     Story => (
       <ThemeProvider>
-        <div className="component-story-main">
+        <div className="story-theme-switcher">
           <ThemeSwitcher />
+        </div>
+        <div className="component-story-main">
           <Story />
         </div>
       </ThemeProvider>

--- a/stories/atoms/components/toast/Toast.stories.mdx
+++ b/stories/atoms/components/toast/Toast.stories.mdx
@@ -21,8 +21,10 @@ import BotAnikImage from '../../../assets/botanik-logo.png'
   decorators={[
     Story => (
       <ThemeProvider>
-        <div className="component-story-main">
+        <div className="story-theme-switcher">
           <ThemeSwitcher />
+        </div>
+        <div className="component-story-main">
           <Story />
         </div>
       </ThemeProvider>

--- a/stories/atoms/components/typography/Typography.stories.mdx
+++ b/stories/atoms/components/typography/Typography.stories.mdx
@@ -19,8 +19,10 @@ import '../component.scss'
   decorators={[
     Story => (
       <ThemeProvider>
-        <div className="component-story-main">
+        <div className="story-theme-switcher">
           <ThemeSwitcher />
+        </div>
+        <div className="component-story-main">
           <Story />
         </div>
       </ThemeProvider>

--- a/stories/molecules/components/footer/Footer.stories.mdx
+++ b/stories/molecules/components/footer/Footer.stories.mdx
@@ -28,7 +28,7 @@ import { Button } from 'ui/atoms/button/Button'
     Story => {
       return (
         <ThemeProvider>
-          <div style={{ padding: '20px 30px' }}>
+          <div className="story-theme-switcher">
             <ThemeSwitcher />
           </div>
           <Story />

--- a/stories/molecules/components/select/Select.stories.mdx
+++ b/stories/molecules/components/select/Select.stories.mdx
@@ -23,7 +23,7 @@ import './select.scss'
   decorators={[
     Story => (
       <ThemeProvider>
-        <div style={{ padding: '20px 30px' }}>
+        <div className="story-theme-switcher">
           <ThemeSwitcher />
         </div>
         <div

--- a/stories/molecules/components/stepper/Stepper.stories.mdx
+++ b/stories/molecules/components/stepper/Stepper.stories.mdx
@@ -26,8 +26,10 @@ import './stepper.scss'
   decorators={[
     Story => (
       <ThemeProvider>
-        <div className="component-story-main">
+        <div className="story-theme-switcher">
           <ThemeSwitcher />
+        </div>
+        <div className="component-story-main">
           <Story />
         </div>
       </ThemeProvider>

--- a/stories/organisms/components/faucet/Faucet.stories.mdx
+++ b/stories/organisms/components/faucet/Faucet.stories.mdx
@@ -23,9 +23,11 @@ import * as env from './env.json'
   decorators={[
     Story => (
       <ThemeProvider>
+        <div className="story-theme-switcher">
+          <ThemeSwitcher />
+        </div>
         <StoreProvider storeParameters={storeParameters}>
           <div className="component-story-main faucet">
-            <ThemeSwitcher />
             <Story />
           </div>
         </StoreProvider>
@@ -50,10 +52,7 @@ For the OKP4 testnets, the Faucet service is configured to send 1 KNOW per reque
 
 ## Overview
 
-<Story
-  name="Overview"
-  args={{ chainId: env.chainId }}
->
+<Story name="Overview" args={{ chainId: env.chainId }}>
   {args => {
     const { theme } = useTheme()
     console.log(JSON.prettyenv)
@@ -81,6 +80,7 @@ To configure the organism, the [@okp4/ui](https://www.npmjs.com/package/@okp4/ui
 ### 1. Create a `config.json` file that declares the COSMOS blockchain configuration
 
 This file contains all the information the organism needs to configure itself:
+
 - the identifier of the COSMOS blockchain (aka the `chainId`).
 - the URL of the [Faucet service](https://github.com/okp4/cosmos-faucet) endpoint on the backend. This service supports any Cosmos based blockchain and is available for the OKP4 testnets networks.
 - the complete description of the blockchain for the registration on Keplr. This is required to request adding new Cosmos-SDK based blockchains that isn't natively integrated to Keplr extension.
@@ -89,11 +89,11 @@ The following `config.json` file is a configuration example for connecting to th
 
 **`config.json`**
 
-<Source code={JSON.stringify(env.default, null, 2)} language='json'/>
+<Source code={JSON.stringify(env.default, null, 2)} language="json" />
 
 ### 2. Instanciate redux stores to init the component
 
-To work, the component uses [redux](https://redux.js.org/) as a state manager and an `eventBus` instance to facilitate communication between the business domains.  
+To work, the component uses [redux](https://redux.js.org/) as a state manager and an `eventBus` instance to facilitate communication between the business domains.
 
 To do this, all you have to do is declare the store parameters in a `store.ts` file to be able to import them later into a `Provider` component that will take care of injecting them into the React context.
 


### PR DESCRIPTION
This PR is part of #459.

It puts the theme switch out of every story where it's not part of the component.

**Current overview story:**
![Capture d’écran 2022-09-02 à 08 48 44](https://user-images.githubusercontent.com/75730728/188076075-d387cbb7-8ae4-4e80-9ee3-42b5dde45e20.png)

**Overview story in PR:**
![Capture d’écran 2022-09-02 à 08 48 34](https://user-images.githubusercontent.com/75730728/188076082-36d02c3c-c6cb-4403-9d46-9dda4cf7c4da.png)

**Current property story:**
![Capture d’écran 2022-09-02 à 08 51 46](https://user-images.githubusercontent.com/75730728/188076336-10299f28-03ae-462c-aa70-d3dc9541c8e2.png)

**Property story in PR:**
![Capture d’écran 2022-09-02 à 08 51 20](https://user-images.githubusercontent.com/75730728/188076271-e232a948-d958-4417-be33-9a51badd7029.png)
