### PR TITLE
style: change select default size to medium

### DIFF
--- a/src/ui/molecules/select/Select.tsx
+++ b/src/ui/molecules/select/Select.tsx
@@ -50,7 +50,7 @@ export type SelectProps = SelectInputProps & {
 // eslint-disable-next-line max-lines-per-function, @typescript-eslint/prefer-readonly-parameter-types
 export const Select = ({
   placeholder,
-  size = 'small',
+  size = 'medium',
   disabled = false,
   hasError = false,
   multiple = false,


### PR DESCRIPTION
This PR changes the default size of the `Select` from `small` to `medium` to match the default size of `TextField` component.