### PR TITLE
docs(text field): fix value control

### DIFF
--- a/stories/atoms/components/textField/TextField.stories.mdx
+++ b/stories/atoms/components/textField/TextField.stories.mdx
@@ -54,10 +54,6 @@ import '../component.scss'
     },
     rightIcon: {
       control: false
-    },
-    value: {
-      control: { type: 'select' },
-      options: ['string', ['array', 'of', 'string']]
     }
   }}
   args={{


### PR DESCRIPTION
This PR fix an issue in the `TextField` story.
Before the change, it was not possible to control the `value` of the `TextField` and the change of the `defaultValue` was not visible.

_Before :_ 
<img width="731" alt="image" src="https://user-images.githubusercontent.com/107192362/188177213-19358cb3-050e-4107-9d7c-ecaee9d1bea6.png">

_After :_ 
<img width="737" alt="image" src="https://user-images.githubusercontent.com/107192362/188176913-3cc333a6-a317-444c-816b-722287e9b699.png">
