### PR TITLE
refactor(faucet): change i18n translation name

### DIFF
--- a/src/ui/organisms/faucet/i18n/index.ts
+++ b/src/ui/organisms/faucet/i18n/index.ts
@@ -3,9 +3,9 @@ import faucet_fr from './faucet_fr.json'
 import type { I18nResource } from 'i18n/utils'
 import { loadTranslations } from 'i18n/utils'
 
-const i18nErrorTranslations: I18nResource[] = [
+const i18nTranslations: I18nResource[] = [
   { lng: 'en', namespace: 'faucet', resource: faucet_en },
   { lng: 'fr', namespace: 'faucet', resource: faucet_fr }
 ]
 
-loadTranslations(i18nErrorTranslations)
+loadTranslations(i18nTranslations)


### PR DESCRIPTION
This PR rename an i18n faucet const : `i18nErrorTranslations` => `i18nTranslations`