### PR TITLE
ci: fix the tag_name variable not showing

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -18,5 +18,5 @@ jobs:
               {
                 "avatar_url":"https://avatars.githubusercontent.com/u/98603954?v=4",
                 "username":"Bot Anik",
-                "content":"🚨 A new version of @${{github.repository}} ${{ github.event.tagName }} has been released! 🎉\n\n👉 Changelog: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.tagName }}\n👉 Documentation: https://ui.okp4.space/?path=/story/welcome--page\n👉 Official repo: https://github.com/${{ github.repository }}\n👉 NPM link: https://www.npmjs.com/package/@${{ github.repository }}"
+                "content":"🚨 A new version of @${{github.repository}} ${{ github.event.release.tag_name }} has been released! 🎉\n\n👉 Changelog: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}\n👉 Documentation: https://ui.okp4.space/?path=/story/welcome--page\n👉 Official repo: https://github.com/${{ github.repository }}\n👉 NPM link: https://www.npmjs.com/package/@${{ github.repository }}"
               }


### PR DESCRIPTION
Fix the tag name not showing on [Discord](https://discord.gg/okp4) webhook message (continuation of #515).

Took the GraphQL object definition instead of the Events Object definition. (in previous PR)