### PR TITLE
Style/file picker size

### DIFF
--- a/src/ui/organisms/filePicker/FilePicker.tsx
+++ b/src/ui/organisms/filePicker/FilePicker.tsx
@@ -30,6 +30,7 @@ export type FilePickerProps = Pick<
 // eslint-disable-next-line max-lines-per-function
 export const FilePicker: React.FC<FilePickerProps> = ({
   clearAll = true,
+  size = 'large',
   ...props
 }: DeepReadonly<FilePickerProps>) => {
   const { t }: UseTranslationResponse = useTranslation()
@@ -107,6 +108,7 @@ export const FilePicker: React.FC<FilePickerProps> = ({
         error={isError}
         errorMessage={errorMessage}
         onDropped={handleDropped}
+        size={size}
       />
       {clearAll && fileList.length > 1 && (
         <div className="okp4-file-picker-clear-all" onClick={handleRemoveAll}>

--- a/src/ui/organisms/filePicker/filePicker.scss
+++ b/src/ui/organisms/filePicker/filePicker.scss
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+  width: 100%;
 
   .okp4-file-picker-list-item-delete {
     cursor: pointer;

--- a/stories/organisms/components/filePicker/FilePicker.stories.mdx
+++ b/stories/organisms/components/filePicker/FilePicker.stories.mdx
@@ -61,7 +61,7 @@ It is a combination of the [FileInput](/docs/atoms-fileinput--overview) and the 
     label: 'Drop your files here, or browse',
     multiple: true,
     acceptedFormats: ['image/*', '.csv'],
-    size: 'medium',
+    size: 'large',
     clearAll: true
   }}
 >
@@ -71,6 +71,8 @@ It is a combination of the [FileInput](/docs/atoms-fileinput--overview) and the 
       <div
         style={{
           display: 'flex',
+          width: '80%',
+          margin: 'auto',
           backgroundImage: `url(${theme === 'dark' ? cosmosDark : cosmosLight})`,
           backgroundSize: 'contain',
           backgroundRepeat: 'no-repeat'


### PR DESCRIPTION
This PR allows you to make the `FilePicker` take 100% of the width by setting the default size of the `FileInput` (in the `FilePicker`) to `large`.

Before : 
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/107192362/189379435-0277e3a7-6938-4155-8445-0693faf7ce76.png">

After: 
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/107192362/189379310-2e81d4e6-3c51-4263-9261-2f7cac93892c.png">

