### PR TITLE
Fix/stepper error state

### DIFF
--- a/src/ui/molecules/stepper/Stepper.tsx
+++ b/src/ui/molecules/stepper/Stepper.tsx
@@ -109,6 +109,7 @@ const initState = (steps: DeepReadonly<List<Step>>): StepperState => {
  * @param action the dispatch action of the reducer.
  * @returns the new state of the stepper.
  */
+// eslint-disable-next-line max-lines-per-function
 const stepperReducer = (
   state: DeepReadonly<StepperState>,
   action: DeepReadonly<StepperAction>
@@ -120,10 +121,14 @@ const stepperReducer = (
         activeStepIndex > 0
           ? state.enabledSteps.get(state.enabledSteps.indexOf(state.activeStepIndex) - 1) ?? 0
           : state.activeStepIndex
+      const currentStepState = state.stepsStatuses.get(activeStepIndex)
       return {
         ...state,
         stepsStatuses: state.stepsStatuses
-          .set(state.activeStepIndex, 'uncompleted')
+          .set(
+            state.activeStepIndex,
+            currentStepState !== 'invalid' ? 'uncompleted' : currentStepState
+          )
           .set(previousStepIndex, 'active'),
         activeStepIndex: previousStepIndex
       }

--- a/src/ui/molecules/stepper/stepper.scss
+++ b/src/ui/molecules/stepper/stepper.scss
@@ -11,7 +11,7 @@ $colors: (
 .okp4-stepper-main {
   @include with-theme() {
     width: 100%;
-    height: 100%;
+    min-height: inherit;
     display: grid;
     row-gap: 15px;
     grid-template-rows: auto 1fr;


### PR DESCRIPTION
This PR is linked to 👉 https://github.com/okp4/ui/issues/520

It keeps the error state when the user clicks the previous button of a step in error.

The current step : 
<img width="980" alt="image" src="https://user-images.githubusercontent.com/107192362/189614609-dbaacb22-c81d-4063-bbb9-8ed3c9b9fd9d.png">

The user clicks the next button and the step is invalid : 
<img width="983" alt="image" src="https://user-images.githubusercontent.com/107192362/189614317-c80f2154-7aef-4c2c-88af-c98b777086db.png">

User clicks the previous button, step remains in error state : 
<img width="976" alt="image" src="https://user-images.githubusercontent.com/107192362/189614421-c62b9908-a6b3-4b9d-9960-b55b62867fd3.png">


🎨 This PR also modifies the style of the stepper: it allows the parent component to define the minimum height of the stepper.