### PR TITLE
TextField : fix resize when full width

### DIFF
--- a/src/ui/atoms/inputBase/InputBase.tsx
+++ b/src/ui/atoms/inputBase/InputBase.tsx
@@ -56,9 +56,9 @@ export type InputBaseProps = {
    */
   readonly disableAreaResize?: boolean
   /**
-   * If true, the user can only resize the height of the text area.
+   * If true, the input will take 100% of its parent's size.
    */
-  readonly resizeHeightOnly?: boolean
+  readonly fullWidth?: boolean
   /**
    * Whether input has a themed border.
    */
@@ -87,7 +87,7 @@ export const InputBase = ({
   multiline = false,
   numberOfLines,
   disableAreaResize = false,
-  resizeHeightOnly = false,
+  fullWidth = false,
   withBorder = false
 }: InputBaseProps): JSX.Element => {
   const containerClass = classNames(`okp4-input-base-container`, {
@@ -101,7 +101,7 @@ export const InputBase = ({
   })
   const textareaClass = classNames(inputClass, 'okp4-input-base-textarea', {
     'disable-resize': multiline && disableAreaResize,
-    'resize-height': resizeHeightOnly
+    'resize-height-only': fullWidth && multiline
   })
   const props = {
     defaultValue,

--- a/src/ui/atoms/inputBase/InputBase.tsx
+++ b/src/ui/atoms/inputBase/InputBase.tsx
@@ -56,6 +56,10 @@ export type InputBaseProps = {
    */
   readonly disableAreaResize?: boolean
   /**
+   * If true, the user can only resize the height of the text area.
+   */
+  readonly resizeHeightOnly?: boolean
+  /**
    * Whether input has a themed border.
    */
   readonly withBorder?: boolean
@@ -83,6 +87,7 @@ export const InputBase = ({
   multiline = false,
   numberOfLines,
   disableAreaResize = false,
+  resizeHeightOnly = false,
   withBorder = false
 }: InputBaseProps): JSX.Element => {
   const containerClass = classNames(`okp4-input-base-container`, {
@@ -95,7 +100,8 @@ export const InputBase = ({
     error: hasError
   })
   const textareaClass = classNames(inputClass, 'okp4-input-base-textarea', {
-    'disable-resize': multiline && disableAreaResize
+    'disable-resize': multiline && disableAreaResize,
+    'resize-height': resizeHeightOnly
   })
   const props = {
     defaultValue,

--- a/src/ui/atoms/inputBase/inputBase.scss
+++ b/src/ui/atoms/inputBase/inputBase.scss
@@ -57,6 +57,10 @@
         outline: none;
       }
 
+      &.resize-height {
+        resize: vertical;
+      }
+
       &.disable-resize {
         resize: none;
       }

--- a/src/ui/atoms/inputBase/inputBase.scss
+++ b/src/ui/atoms/inputBase/inputBase.scss
@@ -57,7 +57,7 @@
         outline: none;
       }
 
-      &.resize-height {
+      &.resize-height-only {
         resize: vertical;
       }
 

--- a/src/ui/atoms/textField/TextField.tsx
+++ b/src/ui/atoms/textField/TextField.tsx
@@ -16,20 +16,14 @@ export type TextFieldProps = InputBaseProps & {
    * Displays a message to the user below the input area.
    */
   readonly helperText?: string
-  /**
-   * If true, the TextField will take 100% of its parent's size.
-   */
-  readonly fullWidth?: boolean
 }
 
 export const TextField: React.FC<TextFieldProps> = ({
   size = 'medium',
   helperText,
-  fullWidth = false,
-  multiline = false,
-  disableAreaResize = false,
   ...props
 }: TextFieldProps): JSX.Element => {
+  const { multiline, disableAreaResize, fullWidth, hasError }: InputBaseProps = props
   const containerClass = classNames(
     `okp4-text-field-main ${multiline && !disableAreaResize ? 'auto' : size}`,
     {
@@ -39,16 +33,11 @@ export const TextField: React.FC<TextFieldProps> = ({
 
   return (
     <div className={containerClass}>
-      <InputBase
-        {...props}
-        disableAreaResize={disableAreaResize}
-        multiline={multiline}
-        resizeHeightOnly={fullWidth}
-      />
+      <InputBase {...props} />
       {helperText && (
         <Typography
           as="div"
-          color={props.hasError ? 'error' : 'info'}
+          color={hasError ? 'error' : 'info'}
           fontSize="x-small"
           fontWeight="bold"
           noWrap

--- a/src/ui/atoms/textField/TextField.tsx
+++ b/src/ui/atoms/textField/TextField.tsx
@@ -26,18 +26,25 @@ export const TextField: React.FC<TextFieldProps> = ({
   size = 'medium',
   helperText,
   fullWidth = false,
+  multiline = false,
+  disableAreaResize = false,
   ...props
 }: TextFieldProps): JSX.Element => {
   const containerClass = classNames(
-    `okp4-text-field-main ${props.multiline && !props.disableAreaResize ? 'auto' : size}`,
+    `okp4-text-field-main ${multiline && !disableAreaResize ? 'auto' : size}`,
     {
-      'full-width': !props.multiline && fullWidth
+      'full-width': fullWidth
     }
   )
 
   return (
     <div className={containerClass}>
-      <InputBase {...props} />
+      <InputBase
+        {...props}
+        disableAreaResize={disableAreaResize}
+        multiline={multiline}
+        resizeHeightOnly={fullWidth}
+      />
       {helperText && (
         <Typography
           as="div"

--- a/src/ui/atoms/textField/TextField.tsx
+++ b/src/ui/atoms/textField/TextField.tsx
@@ -20,44 +20,24 @@ export type TextFieldProps = InputBaseProps & {
    * If true, the TextField will take 100% of its parent's size.
    */
   readonly fullWidth?: boolean
-  /**
-   * If true, the TextField allows multiline text as a text area.
-   */
-  readonly multiline?: boolean
-  /**
-   * If multiline, defines the number of lines of the text area.
-   */
-  readonly numberOfLines?: number
-  /**
-   * If true and multiline, the user can't resize the text area.
-   */
-  readonly disableAreaResize?: boolean
 }
 
 export const TextField: React.FC<TextFieldProps> = ({
   size = 'medium',
   helperText,
   fullWidth = false,
-  multiline = false,
-  numberOfLines,
-  disableAreaResize = false,
   ...props
 }: TextFieldProps): JSX.Element => {
   const containerClass = classNames(
-    `okp4-text-field-main ${multiline && !disableAreaResize ? 'auto' : size}`,
+    `okp4-text-field-main ${props.multiline && !props.disableAreaResize ? 'auto' : size}`,
     {
-      'full-width': !multiline && fullWidth
+      'full-width': !props.multiline && fullWidth
     }
   )
 
   return (
     <div className={containerClass}>
-      <InputBase
-        disableAreaResize={disableAreaResize}
-        multiline={multiline}
-        numberOfLines={numberOfLines}
-        {...props}
-      />
+      <InputBase {...props} />
       {helperText && (
         <Typography
           as="div"

--- a/stories/atoms/components/textField/TextField.stories.mdx
+++ b/stories/atoms/components/textField/TextField.stories.mdx
@@ -267,8 +267,10 @@ The `withBorder` property allows you to add a themed border to the textField and
 ## Multiline
 
 The `multiline` property allows you to write text on several lines. The simple text field becomes a text area.  
-When `multiline` is `true` and [disableAreaResize](/docs/atoms-textfield--disable-area-resize) is `false` the [size](/docs/atoms-textfield--sizes) is automatically `auto`.  
-When `fullWidth` is `true`and [disableAreaResize](/docs/atoms-textfield--disable-area-resize) is `false` the user can only resize the heigth of the TextField.
+When `multiline` is `true` and [disableAreaResize](/docs/atoms-textfield--disable-area-resize) is `false`
+the [size](/docs/atoms-textfield--sizes) is automatically `auto`.  
+When `fullWidth` is `true`and [disableAreaResize](/docs/atoms-textfield--disable-area-resize) is `false`
+the user can only resize the height of the textField.
 
 <Canvas>
   <Story name="Multiline">

--- a/stories/atoms/components/textField/TextField.stories.mdx
+++ b/stories/atoms/components/textField/TextField.stories.mdx
@@ -267,9 +267,9 @@ The `withBorder` property allows you to add a themed border to the textField and
 ## Multiline
 
 The `multiline` property allows you to write text on several lines. The simple text field becomes a text area.  
-When `multiline` is `true` and [disableAreaResize](/docs/atoms-textfield--disable-area-resize) is `false`
-the [size](/docs/atoms-textfield--sizes) is automatically `auto`.  
-When `fullWidth` is `true`and [disableAreaResize](/docs/atoms-textfield--disable-area-resize) is `false`
+When `multiline` is **true** and [disableAreaResize](/docs/atoms-textfield--disable-area-resize) is **false**
+the [size](/docs/atoms-textfield--sizes) is automatically **auto**.  
+When `fullWidth` is **true** and [disableAreaResize](/docs/atoms-textfield--disable-area-resize) is **false**
 the user can only resize the height of the textField.
 
 <Canvas>

--- a/stories/atoms/components/textField/TextField.stories.mdx
+++ b/stories/atoms/components/textField/TextField.stories.mdx
@@ -267,12 +267,21 @@ The `withBorder` property allows you to add a themed border to the textField and
 ## Multiline
 
 The `multiline` property allows you to write text on several lines. The simple text field becomes a text area.  
-When `multiline` is `true` and [disableAreaResize](/docs/atoms-textfield--disable-area-resize) is `false` the [size](/docs/atoms-textfield--sizes) is automatically `auto`.
+When `multiline` is `true` and [disableAreaResize](/docs/atoms-textfield--disable-area-resize) is `false` the [size](/docs/atoms-textfield--sizes) is automatically `auto`.  
+When `fullWidth` is `true`and [disableAreaResize](/docs/atoms-textfield--disable-area-resize) is `false` the user can only resize the heigth of the TextField.
 
 <Canvas>
   <Story name="Multiline">
-    <div style={{ display: 'flex', justifyContent: 'center', maxWidth: '100%' }}>
-      <TextField placeholder="I'm a multiline text field." multiline size="large" />
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '10px',
+        alignItems: 'center'
+      }}
+    >
+      <TextField placeholder="I'm a multiline text field." multiline />
+      <TextField placeholder="I'm a multiline text field in full width." multiline fullWidth />
     </div>
   </Story>
 </Canvas>

--- a/stories/atoms/components/textField/TextField.stories.mdx
+++ b/stories/atoms/components/textField/TextField.stories.mdx
@@ -266,11 +266,9 @@ The `withBorder` property allows you to add a themed border to the textField and
 
 ## Multiline
 
-The `multiline` property allows you to write text on several lines. The simple text field becomes a text area.  
-When `multiline` is **true** and [disableAreaResize](/docs/atoms-textfield--disable-area-resize) is **false**
-the [size](/docs/atoms-textfield--sizes) is automatically **auto**.  
-When `fullWidth` is **true** and [disableAreaResize](/docs/atoms-textfield--disable-area-resize) is **false**
-the user can only resize the height of the textField.
+The `multiline` property allows you to write text on several lines.  
+The simple text field becomes a text area and the [`size`](/docs/atoms-textfield--sizes) is automatically **auto**.  
+When `fullWidth` is **true** the user can only resize the height of the textField.
 
 <Canvas>
   <Story name="Multiline">
@@ -282,8 +280,17 @@ the user can only resize the height of the textField.
         alignItems: 'center'
       }}
     >
-      <TextField placeholder="I'm a multiline text field." multiline />
-      <TextField placeholder="I'm a multiline text field in full width." multiline fullWidth />
+      <TextField
+        placeholder="I'm a multiline text field, so my size is automatically set to auto. You can resize my width and heigh."
+        multiline
+        numberOfLines={5}
+      />
+      <TextField
+        placeholder="I'm a multiline text field in full width. My size is automatically set to auto and you can only resize my heigh."
+        multiline
+        numberOfLines={5}
+        fullWidth
+      />
     </div>
   </Story>
 </Canvas>
@@ -325,7 +332,7 @@ By default, the text area is initialized with two lines.
 ## Disable resizing
 
 If the text field is multiline, the property `disableAreaResize` allows to disable the resizing of the text area.
-When `disableAreaResize` is `false`, then users can define a [size](/docs/atoms-textfield--sizes).
+When `disableAreaResize` is `false`, then users can define a [`size`](/docs/atoms-textfield--sizes).
 
 <Canvas>
   <Story name="Disable area resize">


### PR DESCRIPTION
This PR fixes the resizing problem when the TextField is full width by allowing only the height of the TextField to be resized.

<img width="786" alt="image" src="https://user-images.githubusercontent.com/107192362/191682875-560bf0be-ff94-451d-9c00-c4030badea96.png">
