### PR TITLE
FilePicker : rename clear all property

### DIFF
--- a/src/ui/organisms/filePicker/FilePicker.tsx
+++ b/src/ui/organisms/filePicker/FilePicker.tsx
@@ -24,12 +24,12 @@ export type FilePickerProps = Pick<
   /**
    * Displays a clickable text to delete all selected files.
    */
-  readonly clearAll?: boolean
+  readonly showClearAll?: boolean
 }
 
 // eslint-disable-next-line max-lines-per-function
 export const FilePicker: React.FC<FilePickerProps> = ({
-  clearAll = true,
+  showClearAll = false,
   size = 'large',
   ...props
 }: DeepReadonly<FilePickerProps>) => {
@@ -110,7 +110,7 @@ export const FilePicker: React.FC<FilePickerProps> = ({
         onDropped={handleDropped}
         size={size}
       />
-      {clearAll && fileList.length > 1 && (
+      {showClearAll && fileList.length > 1 && (
         <div className="okp4-file-picker-clear-all" onClick={handleRemoveAll}>
           <Typography fontSize="x-small" fontWeight="xlight" textDecoration="underline">
             {t('filePicker:filePicker.clearAll')}

--- a/stories/organisms/components/filePicker/FilePicker.stories.mdx
+++ b/stories/organisms/components/filePicker/FilePicker.stories.mdx
@@ -62,7 +62,7 @@ It is a combination of the [FileInput](/docs/atoms-fileinput--overview) and the 
     multiple: true,
     acceptedFormats: ['image/*', '.csv'],
     size: 'large',
-    clearAll: true
+    showClearAll: false
   }}
 >
   {args => {
@@ -96,6 +96,36 @@ It is a combination of the [FileInput](/docs/atoms-fileinput--overview) and the 
 ## Properties
 
 <ArgsTable story="Overview" />
+
+## Show clear all
+
+Need to clear all selected files at once?  
+We thought it would be handy to offer you a turnkey way to do it!  
+For that, you only have to pass `showClearAll` to the filePicker and that's it!
+The displayed text is themed and internationalized (english and french) and fits harmoniously above the list.
+By default the `showClearAll` value is **false**.
+
+<Canvas>
+  <Story name="Show clear all">
+    <div
+      style={{
+        display: 'flex'
+      }}
+    >
+      <FilePicker
+        label="Drop your files here, or browse"
+        showClearAll
+        description={
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <Typography as="div" fontFamily="brand" fontSize="small" fontWeight="xlight">
+              Display `Clear all` to remove all the selected files.
+            </Typography>
+          </div>
+        }
+      />
+    </div>
+  </Story>
+</Canvas>
 
 ## Usage
 


### PR DESCRIPTION
This PR renames the `clearAll` property to `showClearAll` property and add the linked doc.

<img width="835" alt="image" src="https://user-images.githubusercontent.com/107192362/190166420-88ebb7f1-c904-4ce9-9629-58649854d8c1.png">

