### PR TITLE
fix: change immutable list name import

### DIFF
--- a/src/adapters/faucet/primary/eventListeners.spec.ts
+++ b/src/adapters/faucet/primary/eventListeners.spec.ts
@@ -1,4 +1,4 @@
-import { List } from 'immutable'
+import { List as ImmutableList } from 'immutable'
 import { EventBus } from 'ts-bus'
 import type { BusEvent } from 'ts-bus/types'
 import type { ReduxStore } from 'domain/faucet/store/store'
@@ -20,7 +20,7 @@ type Data = DeepReadonly<{
 
 const address = 'okp4196877dj4crpxmja2ww2hj2vgy45v6uspkzkt8l'
 const chainId = 'chain#1'
-const accounts = List([
+const accounts = ImmutableList([
   new AccountBuilder().withAddress(address).withPublicKey(new Uint8Array(2)).build()
 ])
 const meta: EventMetadata = { initiator: 'domain:test', timestamp: new Date() }

--- a/src/adapters/wallet/secondary/InMemoryWalletGateway.ts
+++ b/src/adapters/wallet/secondary/InMemoryWalletGateway.ts
@@ -1,4 +1,4 @@
-import { Map, List } from 'immutable'
+import { Map, List as ImmutableList } from 'immutable'
 import { ConnectionError } from 'domain/wallet/entities/errors'
 import type { Accounts, ChainId } from 'domain/wallet/entities/wallet'
 import type { Wallet, WalletId } from 'domain/wallet/ports/walletPort'
@@ -20,7 +20,7 @@ export class InMemoryWalletGateway implements Wallet {
     if (!this.isConnected()) {
       throw new ConnectionError()
     }
-    const accounts = this._accounts.get(chainId) ?? List()
+    const accounts = this._accounts.get(chainId) ?? ImmutableList()
     return Promise.resolve(accounts)
   }
 

--- a/src/adapters/wallet/secondary/KeplrWalletGateway.ts
+++ b/src/adapters/wallet/secondary/KeplrWalletGateway.ts
@@ -7,7 +7,7 @@ import type { Wallet, WalletId } from 'domain/wallet/ports/walletPort'
 import type { Accounts, ChainId } from 'domain/wallet/entities/wallet'
 import { KeplrAccountMapper } from './mapper/account.mapper'
 import type { Keplr } from '@keplr-wallet/types'
-import { List } from 'immutable'
+import { List as ImmutableList } from 'immutable'
 import type { DeepReadonly } from 'superTypes'
 import { asMutable } from 'utils'
 
@@ -123,7 +123,7 @@ export class KeplrWalletGateway implements Wallet {
     if (this.isConnected()) {
       const offlineSigner = (window.keplr as Keplr).getOfflineSigner(chainId)
       const accounts = await offlineSigner.getAccounts()
-      return List(accounts.map(KeplrAccountMapper.mapAccount))
+      return ImmutableList(accounts.map(KeplrAccountMapper.mapAccount))
     }
     throw new ConnectionError(
       "Oops ... Account can't be retrieved because extension is not connected..."

--- a/src/domain/task/entity/task.ts
+++ b/src/domain/task/entity/task.ts
@@ -1,4 +1,4 @@
-import type { List } from 'immutable'
+import type { List as ImmutableList } from 'immutable'
 import type { Entity } from 'domain/common/type'
 
 export type TaskStatus = 'processing' | 'success' | 'error'
@@ -20,4 +20,4 @@ export type Task<T = string, I = string> = Entity<
   I
 >
 
-export type Tasks<T = string, I = string> = List<Task<T, I>>
+export type Tasks<T = string, I = string> = ImmutableList<Task<T, I>>

--- a/src/domain/wallet/entities/wallet.ts
+++ b/src/domain/wallet/entities/wallet.ts
@@ -1,4 +1,4 @@
-import type { Map, List } from 'immutable'
+import type { Map, List as ImmutableList } from 'immutable'
 
 export type ChainId = string
 export type ConnectionStatus = 'connected' | 'not connected'
@@ -10,5 +10,5 @@ export type Account = {
   readonly algorithm: Algorithm
   readonly publicKey: Uint8Array
 }
-export type Accounts = List<Account>
+export type Accounts = ImmutableList<Account>
 export type AccountsByChainId = Map<ChainId, Accounts>

--- a/src/domain/wallet/store/builder/store.builder.spec.ts
+++ b/src/domain/wallet/store/builder/store.builder.spec.ts
@@ -6,7 +6,7 @@ import { WalletStoreBuilder } from './store.builder'
 import type { WalletStoreParameters } from './store.builder'
 import type { AppState } from '../appState'
 import { Dependencies } from '../store'
-import { List, Map } from 'immutable'
+import { List as ImmutableList, Map } from 'immutable'
 import { Account, Accounts, ChainId, ConnectionStatus } from 'domain/wallet/entities/wallet'
 
 type Data = Readonly<
@@ -26,7 +26,9 @@ const state: AppState = {
   connectionStatuses: Map<ChainId, ConnectionStatus>().set('#chain1', 'connected'),
   accounts: Map<ChainId, Accounts>().set(
     '#chain1',
-    List<Account>([{ address: '12345', algorithm: 'ed25519', publicKey: new Uint8Array(2) }])
+    ImmutableList<Account>([
+      { address: '12345', algorithm: 'ed25519', publicKey: new Uint8Array(2) }
+    ])
   )
 }
 

--- a/src/domain/wallet/usecases/enable-wallet/enableWallet.spec.ts
+++ b/src/domain/wallet/usecases/enable-wallet/enableWallet.spec.ts
@@ -1,4 +1,4 @@
-import { Map, List } from 'immutable'
+import { Map, List as ImmutableList } from 'immutable'
 import { EventBus } from 'ts-bus'
 import type { ReduxStore } from '../../store/store'
 import type { AppState } from '../../store/appState'
@@ -145,13 +145,13 @@ describe('Enable wallet', () => {
     const { inMemoryGateway1, store, initialState }: InitialProps = init()
     inMemoryGateway1.setAvailable(true)
     inMemoryGateway1.setConnected(true)
-    inMemoryGateway1.setAccounts(chainId1, List([account1]))
+    inMemoryGateway1.setAccounts(chainId1, ImmutableList([account1]))
     await dispatchEnableWallet(inMemoryGateway1, chainId1, store)
     const statuses: ConnectionStatuses = Map({
       [chainId1]: 'connected'
     })
     const accountsByChainId: AccountsByChainId = Map({
-      [chainId1]: List([account1])
+      [chainId1]: ImmutableList([account1])
     })
     expectEnabledWallet(store, initialState)(statuses, accountsByChainId)
   })
@@ -160,13 +160,13 @@ describe('Enable wallet', () => {
     const { inMemoryGateway1, store, initialState }: InitialProps = init()
     inMemoryGateway1.setAvailable(true)
     inMemoryGateway1.setConnected(true)
-    inMemoryGateway1.setAccounts(chainId1, List([account1, account2]))
+    inMemoryGateway1.setAccounts(chainId1, ImmutableList([account1, account2]))
     await dispatchEnableWallet(inMemoryGateway1, chainId1, store)
     const statuses: ConnectionStatuses = Map({
       [chainId1]: 'connected'
     })
     const accountsByChainId: AccountsByChainId = Map({
-      [chainId1]: List([account1, account2])
+      [chainId1]: ImmutableList([account1, account2])
     })
     expectEnabledWallet(store, initialState)(statuses, accountsByChainId)
   })
@@ -175,8 +175,8 @@ describe('Enable wallet', () => {
     const { inMemoryGateway1, store, initialState }: InitialProps = init()
     inMemoryGateway1.setAvailable(true)
     inMemoryGateway1.setConnected(true)
-    inMemoryGateway1.setAccounts(chainId1, List([account1, account2]))
-    inMemoryGateway1.setAccounts(chainId2, List([account3]))
+    inMemoryGateway1.setAccounts(chainId1, ImmutableList([account1, account2]))
+    inMemoryGateway1.setAccounts(chainId2, ImmutableList([account3]))
     await dispatchEnableWallet(inMemoryGateway1, chainId1, store)
     await dispatchEnableWallet(inMemoryGateway1, chainId2, store)
     const statuses: ConnectionStatuses = Map({
@@ -184,8 +184,8 @@ describe('Enable wallet', () => {
       [chainId2]: 'connected'
     })
     const accountsByChainId: AccountsByChainId = Map({
-      [chainId1]: List([account1, account2]),
-      [chainId2]: List([account3])
+      [chainId1]: ImmutableList([account1, account2]),
+      [chainId2]: ImmutableList([account3])
     })
     expectEnabledWallet(store, initialState)(statuses, accountsByChainId)
   })
@@ -194,13 +194,13 @@ describe('Enable wallet', () => {
     const { inMemoryGateway1, store }: InitialProps = init()
     inMemoryGateway1.setAvailable(true)
     inMemoryGateway1.setConnected(true)
-    inMemoryGateway1.setAccounts(chainId1, List([account1]))
+    inMemoryGateway1.setAccounts(chainId1, ImmutableList([account1]))
     await dispatchEnableWallet(inMemoryGateway1, chainId1, store)
     expect(mockedEventBusPublish).toHaveBeenCalledTimes(2)
     expect(mockedEventBusPublish).toHaveBeenCalledWith(
       {
         type: 'wallet/accountsRetrieved',
-        payload: { chainId: chainId1, accounts: List([account1]) }
+        payload: { chainId: chainId1, accounts: ImmutableList([account1]) }
       },
       expect.objectContaining({ initiator: 'domain:wallet' })
     )

--- a/src/ui/molecules/stepper/Stepper.tsx
+++ b/src/ui/molecules/stepper/Stepper.tsx
@@ -8,7 +8,7 @@ import './i18n/index'
 import { useTranslation } from 'hook/useTranslation'
 import type { UseTranslationResponse } from 'hook/useTranslation'
 import { Typography } from 'ui/atoms/typography/Typography'
-import { List } from 'immutable'
+import { List as ImmutableList } from 'immutable'
 import type { Breakpoints } from 'hook/useBreakpoint'
 import { useBreakpoint } from 'hook/useBreakpoint'
 import { Icon } from 'ui/atoms/icon/Icon'
@@ -18,8 +18,8 @@ export type StepStatus = 'disabled' | 'invalid' | 'completed' | 'active' | 'unco
 export type StepIndex = number
 
 type StepperState = {
-  enabledSteps: List<StepIndex>
-  stepsStatuses: List<StepStatus>
+  enabledSteps: ImmutableList<StepIndex>
+  stepsStatuses: ImmutableList<StepStatus>
   activeStepIndex: StepIndex
 }
 
@@ -28,7 +28,7 @@ type StepperAction =
   | { type: 'stepCompleted' }
   | { type: 'stepFailed' }
   | { type: 'stepperSubmitted' }
-  | { type: 'stepperReseted'; payload: List<Step> }
+  | { type: 'stepperReseted'; payload: ImmutableList<Step> }
 
 export type Step = {
   /**
@@ -87,15 +87,15 @@ export type StepperProps = {
  * @param steps the steps of the stepper.
  * @returns the initial state of the stepper.
  */
-const initState = (steps: DeepReadonly<List<Step>>): StepperState => {
+const initState = (steps: DeepReadonly<ImmutableList<Step>>): StepperState => {
   const firstActiveIndex = steps.findIndex((step: DeepReadonly<Step>) => step.status === 'active')
   const initialActiveStep = firstActiveIndex > -1 ? firstActiveIndex : 0
   return {
     enabledSteps: steps.reduce(
-      (acc: DeepReadonly<List<StepIndex>>, curr: DeepReadonly<Step>, index: number) => {
-        return curr.status !== 'disabled' ? List([...acc, index]) : acc
+      (acc: DeepReadonly<ImmutableList<StepIndex>>, curr: DeepReadonly<Step>, index: number) => {
+        return curr.status !== 'disabled' ? ImmutableList([...acc, index]) : acc
       },
-      List()
+      ImmutableList()
     ),
     stepsStatuses: steps.map((step: DeepReadonly<Step>, index: number) =>
       index === initialActiveStep ? 'active' : step.status ?? 'uncompleted'
@@ -179,8 +179,8 @@ export const Stepper: React.FC<StepperProps> = ({
 
   const [state, dispatch]: UseReducer<StepperState, StepperAction> = useReducer<
     Reducer<StepperState, StepperAction>,
-    DeepReadonly<List<Step>>
-  >(stepperReducer, List(steps), initState)
+    DeepReadonly<ImmutableList<Step>>
+  >(stepperReducer, ImmutableList(steps), initState)
 
   const handlePreviousClick = useCallback((): void => {
     dispatch({ type: 'previousClicked' })
@@ -210,7 +210,7 @@ export const Stepper: React.FC<StepperProps> = ({
 
   const handleReset = useCallback((): void => {
     onReset?.()
-    dispatch({ type: 'stepperReseted', payload: List(steps) })
+    dispatch({ type: 'stepperReseted', payload: ImmutableList(steps) })
   }, [onReset, steps])
 
   const isPreviousDisabled = useMemo(

--- a/src/ui/providers/storeProvider.tsx
+++ b/src/ui/providers/storeProvider.tsx
@@ -1,4 +1,4 @@
-import type { List } from 'immutable'
+import type { List as ImmutableList } from 'immutable'
 import React from 'react'
 import type { ReactReduxContextValue } from 'react-redux'
 import { Provider } from 'react-redux'
@@ -13,7 +13,7 @@ export type StoreContext = React.Context<ReactReduxContextValue<any>>
 export type StoreParameter = [StoreContext, Store<any>]
 
 export type StoreProviderProps = DeepReadonly<{
-  storeParameters: List<StoreParameter>
+  storeParameters: ImmutableList<StoreParameter>
   children: React.ReactElement
 }>
 

--- a/stories/organisms/components/faucet/store.ts
+++ b/stories/organisms/components/faucet/store.ts
@@ -1,4 +1,4 @@
-import { List } from 'immutable'
+import { List as ImmutableList } from 'immutable'
 import { HTTPFaucetGateway } from 'adapters/faucet/secondary/graphql/HTTPFaucetGateway'
 import { KeplrWalletGateway } from 'adapters/wallet/secondary/KeplrWalletGateway'
 import { WalletRegistryGateway } from 'adapters/wallet/secondary/WalletRegistryGateway'
@@ -43,7 +43,7 @@ const walletStore = new WalletStoreBuilder()
   .build()
 const walletStoreParameter: StoreParameter = [WalletContext, walletStore]
 
-export default List([
+export default ImmutableList([
   faucetStoreParameter,
   errorStoreParameter,
   walletStoreParameter,

--- a/stories/organisms/components/filePicker/store.ts
+++ b/stories/organisms/components/filePicker/store.ts
@@ -1,4 +1,4 @@
-import { List } from 'immutable'
+import { List as ImmutableList } from 'immutable'
 import { FileStoreBuilder } from 'domain/file/store/builder/store.builder'
 import { FileContext } from 'context/storeContext/fileContext'
 import { createEventBusInstance } from 'eventBus/index'
@@ -11,4 +11,4 @@ const eventBusInstance = createEventBusInstance()
 const fileStore = new FileStoreBuilder().withEventBus(eventBusInstance).build()
 const fileStoreParameter: StoreParameter = [FileContext, fileStore]
 
-export default List([fileStoreParameter])
+export default ImmutableList([fileStoreParameter])


### PR DESCRIPTION
When importing the `List` component into an application, we observed that the export of the `List` component collided with the export of the `List` of `Immutable`.

Here is the type before the fix:  

<img width="866" alt="Capture d’écran 2022-09-16 à 15 51 03" src="https://user-images.githubusercontent.com/35332974/190655136-1098b79e-febd-4ed7-acd4-389ca7e3339b.png">

Indeed, rollup exported the `List` of the `Immutable` library to the detriment of the `List` component.

So we renamed each import of the `List` from `Immutable` as `ImmutableList` in order to find the export of the `List` component in the build and to be able to use it in other applications.

Here is the correct type of the `List` component after the fix:

<img width="365" alt="Capture d’écran 2022-09-16 à 15 50 31" src="https://user-images.githubusercontent.com/35332974/190655801-deababfd-5e7e-441d-9b28-7acc6702c0c4.png">

