### PR TITLE
ci: checkout out repository before checking new dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Check for new dependencies
         uses: hiwelo/new-dependencies-action@1.0.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.OKP4_TOKEN }}
 
   lint-branch-name:
     runs-on: ubuntu-20.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,10 +76,13 @@ jobs:
         run: |
           yarn lint
 
-  report_new_dependencies:
+  report-new-dependencies:
     runs-on: ubuntu-20.04
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
       - name: Check for new dependencies
         uses: hiwelo/new-dependencies-action@1.0.1
         with:


### PR DESCRIPTION
This PR fixes the report new dependencies step in the ci workflows.

As a result an output like the following is to be expected in the PR page:

![hiwelo_action](https://user-images.githubusercontent.com/26690002/191021274-1afcc16e-ced5-43ae-b24c-9463cd014609.png)
This is when a new item called 'smallest' version 1.0.1 is added to the package.json dependencies section.

**Note**
We additionaly experimented another action labelled lirantal/github-action-new-dependencies-advisor@v1.1.1 
The latter adds metrics on the reliability and quality of each new dependency:
![lirantal_action](https://user-images.githubusercontent.com/26690002/191021026-dd465e88-a182-454d-a0dd-11fe0941434a.png)
The [liranthal github action](https://github.com/lirantal/github-action-new-dependencies-advisor) appears to be under the MIT license although it advertises a commercial logo. 

I am interested in feedback on whether we should choose liranthal or stick to hiwelo/new-dependencies-action.
