### PR TITLE
Feat/upload files

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     '<rootDir>/src/adapters/faucet/secondary/graphql/',
     'index.ts',
     'test.helper.ts',
+    '<rootDir>/src/adapters/file/secondary/s3/',
     'InMemory'
   ],
   globals: {
@@ -20,7 +21,8 @@ module.exports = {
   moduleNameMapper: {
     '^domain/(.*)$': '<rootDir>/src/domain/$1',
     '^adapters/(.*)$': '<rootDir>/src/adapters/$1',
-    '^utils': '<rootDir>/src/utils.ts'
+    '^utils': '<rootDir>/src/utils.ts',
+    '^uuid$': require.resolve('uuid')
   },
   setupFilesAfterEnv: ['<rootDir>/setup-jest.js']
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,9 +4,10 @@ module.exports = {
   testEnvironment: 'jsdom',
   moduleDirectories: ['node_modules'],
   coveragePathIgnorePatterns: [
-    '<rootDir>/src/adapters/faucet/secondary/graphql/documents/',
+    '<rootDir>/src/adapters/faucet/secondary/graphql/',
     'index.ts',
-    'test.helper.ts'
+    'test.helper.ts',
+    'InMemory'
   ],
   globals: {
     window: {}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
   },
   "dependencies": {
     "@javelin/ecs": "^1.0.0-alpha.13",
+    "@aws-sdk/client-s3": "^3.171.0",
+    "@aws-sdk/lib-storage": "^3.171.0",
     "@radix-ui/react-switch": "^1.0.0",
     "@radix-ui/react-toast": "^1.0.0",
     "@urql/core": "^3.0.1",

--- a/src/adapters/file/index.ts
+++ b/src/adapters/file/index.ts
@@ -1,0 +1,2 @@
+export * from './secondary/FileRegistryGateway'
+export * from './secondary/s3/S3FileGateway'

--- a/src/adapters/file/secondary/FileRegistryGateway.ts
+++ b/src/adapters/file/secondary/FileRegistryGateway.ts
@@ -1,0 +1,28 @@
+import { Map } from 'immutable'
+import { GatewayError } from 'domain/file/entity/error'
+import type { FilePort, FileRegistryPort } from 'domain/file/port/filePort'
+import type { DeepReadonly } from 'superTypes'
+
+export class FileRegistryGateway implements FileRegistryPort {
+  private fileGateways: Map<string, FilePort> = Map()
+
+  public readonly get = (id: string): FilePort => {
+    const fileGateway = this.fileGateways.get(id)
+    if (!fileGateway) {
+      throw new GatewayError(`Ooops ... No gateway was found with this id : ${id}`)
+    }
+    return fileGateway
+  }
+
+  public readonly register = (...fileGateways: DeepReadonly<FilePort[]>): void => {
+    fileGateways.forEach((fileGateway: DeepReadonly<FilePort>) => {
+      this.fileGateways = this.fileGateways.set(fileGateway.id(), fileGateway)
+    })
+  }
+
+  public readonly clear = (): void => {
+    this.fileGateways = this.fileGateways.clear()
+  }
+
+  public readonly names = (): readonly string[] => Object.keys(this.fileGateways)
+}

--- a/src/adapters/file/secondary/InMemoryFileGateway.ts
+++ b/src/adapters/file/secondary/InMemoryFileGateway.ts
@@ -1,0 +1,38 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { UnspecifiedError, UploadError } from 'domain/file/entity/error'
+import type {
+  FileExecutor,
+  FilePort,
+  FilePortId,
+  FileProgressHandler,
+  FileToUpload
+} from 'domain/file/port/filePort'
+import type { DeepReadonly } from 'superTypes'
+
+export class InMemoryFileGateway implements FilePort {
+  private _hasUploadError: boolean = false
+  private _hasUnspecifiedError: boolean = false
+
+  public readonly id = (): FilePortId => 'in-memory'
+
+  public readonly execute = async (handler: FileExecutor): Promise<void> => handler(this)
+
+  public readonly upload = async (
+    _file: DeepReadonly<FileToUpload>,
+    _target: string,
+    onProgressChange?: FileProgressHandler
+  ): Promise<void> => {
+    if (this._hasUploadError) throw new UploadError()
+    if (this._hasUnspecifiedError) throw new UnspecifiedError()
+    onProgressChange?.(5)
+    return Promise.resolve()
+  }
+
+  public readonly setUploadError = (): void => {
+    this._hasUploadError = true
+  }
+
+  public readonly setUnspecifiedError = (): void => {
+    this._hasUnspecifiedError = true
+  }
+}

--- a/src/adapters/file/secondary/s3/S3FileGateway.ts
+++ b/src/adapters/file/secondary/s3/S3FileGateway.ts
@@ -1,0 +1,57 @@
+import type {
+  FileExecutor,
+  FilePort,
+  FilePortId,
+  FileProgressHandler,
+  FileToUpload,
+  UploadFile
+} from 'domain/file/port/filePort'
+import type { DeepReadonly } from 'superTypes'
+import type { Progress } from '@aws-sdk/lib-storage'
+import { Upload } from '@aws-sdk/lib-storage'
+import { UploadError } from 'domain/file/entity/error'
+import type { S3Config } from './client'
+import { client } from './client'
+
+export class S3FileGateway implements FilePort {
+  private readonly config: S3Config
+  constructor(config: DeepReadonly<S3Config>) {
+    this.config = config
+  }
+
+  public readonly id = (): FilePortId => 's3'
+
+  public readonly execute = async (handler: FileExecutor): Promise<void> => handler(this)
+
+  public readonly upload: UploadFile = async (
+    file: DeepReadonly<FileToUpload>,
+    target: string,
+    onProgressChange?: FileProgressHandler
+  ): Promise<void> => {
+    try {
+      const s3Client = client(this.config)
+
+      const s3Upload = new Upload({
+        client: s3Client,
+        params: {
+          Bucket: target,
+          Key: file.name,
+          Body: file.stream
+        }
+      })
+
+      if (onProgressChange) {
+        s3Upload.on('httpUploadProgress', (progress: DeepReadonly<Progress>) => {
+          onProgressChange(progress.loaded)
+        })
+      }
+      await s3Upload.done()
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : 'Oops... We encountered an unspecified error while trying to upload files...'
+      throw new UploadError(errorMessage)
+    }
+  }
+}

--- a/src/adapters/file/secondary/s3/client.ts
+++ b/src/adapters/file/secondary/s3/client.ts
@@ -1,0 +1,23 @@
+import { S3Client } from '@aws-sdk/client-s3'
+import type { DeepReadonly } from 'superTypes'
+
+export type S3Config = {
+  endpoint: string
+  region: string
+  credentials: {
+    accessKeyId: string
+    secretAccessKey: string
+  }
+}
+export const client = (config: DeepReadonly<S3Config>): S3Client => {
+  const { endpoint, credentials, region }: S3Config = config
+  return new S3Client({
+    endpoint,
+    region,
+    credentials: {
+      accessKeyId: credentials.accessKeyId,
+      secretAccessKey: credentials.secretAccessKey
+    },
+    forcePathStyle: true
+  })
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,2 +1,3 @@
 export * from './faucet/index'
 export * from './wallet/index'
+export * from './file/index'

--- a/src/adapters/task/primary/eventListeners.ts
+++ b/src/adapters/task/primary/eventListeners.ts
@@ -7,7 +7,7 @@ import type { TypedBusEvent } from 'eventBus/eventBus'
 import type { RegisterTaskActions } from 'domain/task/usecase/register-task/actionCreators'
 import type { AmendTaskStatusActions } from 'domain/task/usecase/amend-task-status/actionCreators'
 import type { SetTaskProgressValueActions } from 'domain/task/usecase/set-task-progress-value/actionCreators'
-import { setTaskProgressValue } from 'domain/task'
+import { setTaskProgressValue } from 'domain/task/usecase/set-task-progress-value/setTaskProgressValue'
 
 export const initTaskEventListeners = (
   store: DeepReadonly<ReduxStore>,

--- a/src/adapters/task/primary/eventListeners.ts
+++ b/src/adapters/task/primary/eventListeners.ts
@@ -6,6 +6,8 @@ import type { DeepReadonly } from 'superTypes'
 import type { TypedBusEvent } from 'eventBus/eventBus'
 import type { RegisterTaskActions } from 'domain/task/usecase/register-task/actionCreators'
 import type { AmendTaskStatusActions } from 'domain/task/usecase/amend-task-status/actionCreators'
+import type { SetTaskProgressValueActions } from 'domain/task/usecase/set-task-progress-value/actionCreators'
+import { setTaskProgressValue } from 'domain/task'
 
 export const initTaskEventListeners = (
   store: DeepReadonly<ReduxStore>,
@@ -31,6 +33,20 @@ export const initTaskEventListeners = (
       >
     ) => {
       store.dispatch(amendTaskStatus(event.payload))
+    }
+  )
+  eventBus.subscribe(
+    'task/taskProgressValueSetReceived',
+    (
+      event: DeepReadonly<
+        TypedBusEvent<
+          DeepReadonly<
+            ReturnType<typeof SetTaskProgressValueActions['taskProgressValueSetReceived']>
+          >
+        >
+      >
+    ) => {
+      store.dispatch(setTaskProgressValue(event.payload))
     }
   )
 }

--- a/src/domain/common/test.helper.ts
+++ b/src/domain/common/test.helper.ts
@@ -29,3 +29,17 @@ export const expectEventParameters = <T>(
     })
   }
 }
+
+/**
+ * This is a hack to force error's payload context to be cleaned up in the publish first parameter when called with error event.
+ * WHY? --> it's not possible to mock only the stack property of the error because the mock applies to the entire Error class
+ */
+export const cleanErrorStack = (mockedEventBusPublish: jest.SpyInstance): void => {
+  const foundErrorEvent = mockedEventBusPublish.mock.calls
+    .flat()
+    // eslint-disable-next-line @typescript-eslint/typedef
+    .find(elt => elt.type === 'error/errorThrown')
+  if (foundErrorEvent?.payload?.context) {
+    foundErrorEvent.payload.context = {}
+  }
+}

--- a/src/domain/file/command/uploadFiles.ts
+++ b/src/domain/file/command/uploadFiles.ts
@@ -1,0 +1,5 @@
+export type UploadFiles<I = string> = {
+  filePortId: string
+  target: string
+  fileIds?: I[]
+}

--- a/src/domain/file/entity/error.ts
+++ b/src/domain/file/entity/error.ts
@@ -1,6 +1,24 @@
+import type { DeepReadonly } from 'superTypes'
+
 export class UnspecifiedError extends Error {
   constructor(message?: string) {
     super(message)
     this.name = 'UnspecifiedError'
+  }
+}
+
+export class GatewayError extends Error {
+  constructor(message?: string) {
+    super(message)
+    this.name = 'GatewayError'
+  }
+}
+
+export class UploadError extends Error {
+  public context: Record<string, string> | undefined = {}
+  constructor(message?: string, context?: DeepReadonly<Record<string, string>>) {
+    super(message)
+    this.name = 'UploadError'
+    this.context = context
   }
 }

--- a/src/domain/file/port/filePort.ts
+++ b/src/domain/file/port/filePort.ts
@@ -1,0 +1,35 @@
+import type { DeepReadonly } from 'superTypes'
+import type { MediaType } from 'domain/common/type'
+
+export type FilePortId = string
+
+export type FileToUpload = {
+  id: string
+  name: string
+  stream: ReadableStream
+  size: number
+  type: MediaType
+}
+
+export type UploadFile = (
+  file: DeepReadonly<FileToUpload>,
+  target: string, // the root folder / bucket / etc. in which the file must be uploaded on server.
+  onProgressChange?: FileProgressHandler
+) => Promise<void>
+
+export type FileRegistryPort = {
+  readonly get: (id: FilePortId) => FilePort
+  readonly names: () => readonly string[]
+}
+
+export type FilePort = {
+  readonly id: () => FilePortId
+  readonly execute: (handler: FileExecutor) => Promise<void>
+}
+
+export type FileExecutorHandler = {
+  upload: UploadFile
+}
+export type FileExecutor = (handler: DeepReadonly<FileExecutorHandler>) => void
+
+export type FileProgressHandler = (value?: number) => void

--- a/src/domain/file/store/builder/store.builder.spec.ts
+++ b/src/domain/file/store/builder/store.builder.spec.ts
@@ -7,10 +7,13 @@ import type { FileStoreParameters } from './store.builder'
 import type { AppState } from '../appState'
 import { FileBuilder } from 'domain/file/builder/file.builder'
 import { FileEntity } from 'domain/file/entity/file'
+import { Dependencies } from '../store'
+import { FileRegistryGateway } from 'adapters/file'
 
 type Data = Readonly<
   Partial<{
     initialStoreParameters: FileStoreParameters
+    dependencies: Dependencies
     eventBus: EventBus
     preloadedState: AppState
   }> & {
@@ -18,6 +21,7 @@ type Data = Readonly<
   }
 >
 const eventBusInstance = new EventBus()
+const fileRegistryGateway = new FileRegistryGateway()
 const file1 = new FileBuilder()
   .withId('id1')
   .withName('image1')
@@ -35,23 +39,28 @@ const state1: AppState = {
 
 describe('Build a File store', () => {
   describe.each`
-    initialStoreParameters            | eventBus            | preloadedState | expectedStatus
-    ${undefined}                      | ${eventBusInstance} | ${undefined}   | ${true}
-    ${undefined}                      | ${eventBusInstance} | ${state1}      | ${true}
-    ${{ eventBus: eventBusInstance }} | ${undefined}        | ${undefined}   | ${true}
-    ${undefined}                      | ${eventBusInstance} | ${{}}          | ${false}
-    ${undefined}                      | ${{}}               | ${undefined}   | ${false}
-    ${undefined}                      | ${undefined}        | ${undefined}   | ${false}
-    ${{ preloadedState: {} }}         | ${undefined}        | ${undefined}   | ${false}
-    ${{ eventBus: {} }}               | ${undefined}        | ${undefined}   | ${false}
+    initialStoreParameters                            | dependencies                    | eventBus            | preloadedState | expectedStatus
+    ${undefined}                                      | ${undefined}                    | ${eventBusInstance} | ${undefined}   | ${true}
+    ${undefined}                                      | ${{ fileRegistryGateway }}      | ${eventBusInstance} | ${undefined}   | ${true}
+    ${undefined}                                      | ${undefined}                    | ${eventBusInstance} | ${state1}      | ${true}
+    ${{ eventBus: eventBusInstance }}                 | ${undefined}                    | ${undefined}        | ${undefined}   | ${true}
+    ${undefined}                                      | ${undefined}                    | ${eventBusInstance} | ${{}}          | ${false}
+    ${undefined}                                      | ${undefined}                    | ${{}}               | ${undefined}   | ${false}
+    ${undefined}                                      | ${undefined}                    | ${undefined}        | ${undefined}   | ${false}
+    ${{ preloadedState: {} }}                         | ${undefined}                    | ${undefined}        | ${undefined}   | ${false}
+    ${{ eventBus: {} }}                               | ${undefined}                    | ${undefined}        | ${undefined}   | ${false}
+    ${undefined}                                      | ${{ foo: fileRegistryGateway }} | ${eventBusInstance} | ${undefined}   | ${false}
+    ${{ dependencies: { foo: fileRegistryGateway } }} | ${undefined}                    | ${eventBusInstance} | ${undefined}   | ${false}
   `(
-    'Given that eventBus is <$eventBus> adn preloadedState is <$preloadedState>',
-    ({ initialStoreParameters, eventBus, preloadedState, expectedStatus }: Data) => {
+    'Given that dependencies are <$dependencies>, eventBus is <$eventBus> adn preloadedState is <$preloadedState>',
+    ({ initialStoreParameters, dependencies, eventBus, preloadedState, expectedStatus }: Data) => {
       describe('When building a File Store', () => {
         const store = (): Store<AppState, AnyAction> => {
           // eslint-disable-next-line functional/no-let
           let fileStoreBuilder = new FileStoreBuilder(initialStoreParameters)
-
+          if (dependencies !== undefined) {
+            fileStoreBuilder = fileStoreBuilder.withDependencies(dependencies)
+          }
           if (eventBus !== undefined) {
             fileStoreBuilder = fileStoreBuilder.withEventBus(eventBus)
           }

--- a/src/domain/file/store/selector/file.selector.ts
+++ b/src/domain/file/store/selector/file.selector.ts
@@ -19,3 +19,28 @@ export const getFiles: (state: DeepReadonly<AppState>) => FileDescriptor[] = cre
       .toArray()
       .map(({ id, name, size, type }: FileEntity) => ({ id, name, size, type }))
 )
+
+export const getFilesSizeByIds: (state: DeepReadonly<AppState>, ids: Readonly<string[]>) => number =
+  createSelector(
+    [
+      (state: DeepReadonly<AppState>): FileById => state.file.byId,
+      (_state: DeepReadonly<AppState>, ids: Readonly<string[]>): Readonly<string[]> => ids
+    ],
+    (files: DeepReadonly<FileById>, ids: Readonly<string[]>): number =>
+      ids.reduce((acc: number, cur: string) => {
+        const found = files.get(cur)
+        return found ? acc + found.size : acc
+      }, 0)
+  )
+
+export const getTotalFilesSize: (state: DeepReadonly<AppState>) => number = createSelector(
+  (state: DeepReadonly<AppState>): AppState => state,
+  (state: DeepReadonly<AppState>): number =>
+    getFilesSizeByIds(
+      state,
+      state.file.byId
+        .toIndexedSeq()
+        .toArray()
+        .map((value: FileEntity) => value.id)
+    )
+)

--- a/src/domain/file/store/store.ts
+++ b/src/domain/file/store/store.ts
@@ -8,8 +8,14 @@ import type { AppState } from './appState'
 import rootReducer from './reducer/file.reducer'
 import { eventBusMiddleware } from 'domain/common/store.helper'
 import type { DeepReadonly } from 'superTypes'
+import type { FileRegistryPort } from '../port/filePort'
+
+export interface Dependencies {
+  readonly fileRegistryGateway: FileRegistryPort
+}
 
 export const configureStore = (
+  dependencies: Partial<Dependencies>,
   eventBus: DeepReadonly<EventBus>,
   preloadedState?: DeepReadonly<AppState>
 ): Store<AppState> =>
@@ -18,13 +24,13 @@ export const configureStore = (
     preloadedState,
     composeWithDevTools(
       applyMiddleware(
-        thunk as ThunkMiddleware<AppState, Action>,
+        thunk.withExtraArgument(dependencies) as ThunkMiddleware<AppState, Action, Dependencies>,
         eventBusMiddleware(eventBus, 'domain:file')
       )
     )
   )
 
 export type ReduxStore = Store<AppState> & {
-  readonly dispatch: ThunkDispatch<AppState, undefined, Action>
+  readonly dispatch: ThunkDispatch<AppState, Dependencies, Action>
 }
-export type ThunkResult<R> = ThunkAction<R, AppState, undefined, Action>
+export type ThunkResult<R> = ThunkAction<R, AppState, Dependencies, Action>

--- a/src/domain/file/usecase/upload-files/uploadFiles.spec.ts
+++ b/src/domain/file/usecase/upload-files/uploadFiles.spec.ts
@@ -20,7 +20,6 @@ import { AppState } from 'domain/file/store/appState'
 import { OrderedMap, OrderedSet } from 'immutable'
 import { FileEntity } from 'domain/file/entity/file'
 import { FileBuilder } from 'domain/file/builder/file.builder'
-import { UnspecifiedError, UploadError } from 'domain/file/entity/error'
 import { Error } from 'domain/error/entity/error'
 
 interface InitialProps {
@@ -45,7 +44,6 @@ interface Data {
 
 const eventBus = new EventBus()
 const mockedEventBusPublish = jest.spyOn(eventBus, 'publish')
-// jest.mock('../../entity/error')
 
 const init = (preloadedState: AppState): InitialProps => {
   const fileRegistryGateway = new FileRegistryGateway()
@@ -226,7 +224,7 @@ describe('Upload files', () => {
     ${false}       | ${false}            | ${false}                 | ${filesToUpload3} | ${state3}      | ${state1}     | ${expectedEventParameters1}
     ${false}       | ${false}            | ${false}                 | ${filesToUpload4} | ${state3}      | ${state1}     | ${expectedEventParameters1}
   `(
-    'Given that ',
+    'Given that there are file(s) to upload',
     ({
       hasUploadError,
       hasUnspecifiedError,
@@ -244,7 +242,9 @@ describe('Upload files', () => {
         afterAll(() => {
           jest.clearAllMocks()
         })
-        test('Then, ', async () => {
+        test(`Then, expect state to be ${JSON.stringify(
+          expectedState
+        )} and eventParameters to be ${JSON.stringify(expectedEventParameters)}`, async () => {
           await store.dispatch(uploadFiles(filesToUpload))
           expect(store.getState()).toStrictEqual(expectedState)
           cleanErrorStack(mockedEventBusPublish)

--- a/src/domain/file/usecase/upload-files/uploadFiles.spec.ts
+++ b/src/domain/file/usecase/upload-files/uploadFiles.spec.ts
@@ -1,0 +1,260 @@
+import short from 'short-uuid'
+import { EventBus } from 'ts-bus'
+import { ErrorBuilder } from 'domain/error/builder/error.builder'
+import { InMemoryFileGateway } from 'adapters/file/secondary/InMemoryFileGateway'
+import type { ReduxStore } from 'domain/file/store/store'
+import {
+  getExpectedEventParameter,
+  EventParameter,
+  expectEventParameters,
+  cleanErrorStack
+} from 'domain/common/test.helper'
+import { TaskRegisterReceivedPayload } from 'domain/task/event/taskRegisterReceived'
+import { TaskStatusAmendReceivedPayload } from 'domain/task/event/taskStatusAmendReceived'
+import { TaskProgressValueSetReceivedPayload } from 'domain/task/event/taskProgressValueSetReceived'
+import { UploadFiles } from 'domain/file/command/uploadFiles'
+import { FileStoreBuilder } from 'domain/file/store/builder/store.builder'
+import { FileRegistryGateway } from 'adapters/file'
+import { uploadFiles } from './uploadFiles'
+import { AppState } from 'domain/file/store/appState'
+import { OrderedMap, OrderedSet } from 'immutable'
+import { FileEntity } from 'domain/file/entity/file'
+import { FileBuilder } from 'domain/file/builder/file.builder'
+import { UnspecifiedError, UploadError } from 'domain/file/entity/error'
+import { Error } from 'domain/error/entity/error'
+
+interface InitialProps {
+  store: ReduxStore
+  fileGateway: InMemoryFileGateway
+  fileRegistryGateway: FileRegistryGateway
+}
+
+interface Data {
+  hasUploadError: boolean
+  hasUnspecifiedError: boolean
+  clearFileRegistryGateway: boolean
+  filesToUpload: UploadFiles
+  preloadedState: AppState
+  expectedState: AppState
+  expectedEventParameters: EventParameter<
+    | TaskRegisterReceivedPayload
+    | TaskStatusAmendReceivedPayload
+    | TaskProgressValueSetReceivedPayload
+  >[]
+}
+
+const eventBus = new EventBus()
+const mockedEventBusPublish = jest.spyOn(eventBus, 'publish')
+// jest.mock('../../entity/error')
+
+const init = (preloadedState: AppState): InitialProps => {
+  const fileRegistryGateway = new FileRegistryGateway()
+  const fileGateway = new InMemoryFileGateway()
+  fileRegistryGateway.register(fileGateway)
+  const store = new FileStoreBuilder()
+    .withEventBus(eventBus)
+    .withDependencies({ fileRegistryGateway })
+    .withPreloadedState(preloadedState)
+    .build()
+  return { store, fileGateway, fileRegistryGateway }
+}
+
+describe('Upload files', () => {
+  const initiator = 'domain:file'
+  const fakedUuid = 'foobar'
+  const fileTaskType = 'file#upload-files'
+  const fakedDate = new Date('2021-01-01T09:00:00.000Z')
+  const stream = new ReadableStream()
+
+  // Command payloads
+  const filesToUpload1: UploadFiles = {
+    filePortId: 'in-memory',
+    target: ''
+  }
+
+  const filesToUpload2: UploadFiles = {
+    filePortId: 'in-memory',
+    target: 'fake-target',
+    fileIds: [fakedUuid]
+  }
+
+  const filesToUpload3: UploadFiles = {
+    filePortId: 'in-memory',
+    target: 'fake-target'
+  }
+
+  const filesToUpload4: UploadFiles = {
+    filePortId: 'in-memory',
+    target: 'fake-target',
+    fileIds: ['id1']
+  }
+
+  // Event payloads
+  const taskToRegister1: TaskRegisterReceivedPayload = {
+    id: fakedUuid,
+    type: fileTaskType,
+    progress: {
+      min: 0,
+      max: 100,
+      current: 0
+    }
+  }
+
+  const taskStatusToAmend1: TaskStatusAmendReceivedPayload = {
+    id: taskToRegister1.id,
+    status: 'error'
+  }
+
+  const taskStatusToAmend2: TaskStatusAmendReceivedPayload = {
+    id: taskToRegister1.id,
+    status: 'success'
+  }
+
+  const taskProgressValueToSet1: TaskProgressValueSetReceivedPayload = {
+    id: taskToRegister1.id,
+    progressValue: 5
+  }
+
+  // Entities
+  const file1 = new FileBuilder()
+    .withId('id1')
+    .withName('image1')
+    .withSize(100)
+    .withType('image/png')
+    .withStream(stream)
+    .build()
+
+  const file2 = new FileBuilder()
+    .withId('id2')
+    .withName('report1')
+    .withSize(1000)
+    .withType('csv')
+    .withStream(stream)
+    .build()
+
+  const unspecifiedError = new ErrorBuilder()
+    .withId(fakedUuid)
+    .withTimestamp(fakedDate)
+    .withMessageKey('domain.error.unspecified-error')
+    .withType('unspecified-error')
+    .build()
+
+  const gatewayError = new ErrorBuilder()
+    .withId(fakedUuid)
+    .withTimestamp(fakedDate)
+    .withMessageKey('domain.error.gateway-error')
+    .withType('gateway-error')
+    .build()
+
+  const uploadError = new ErrorBuilder()
+    .withId(fakedUuid)
+    .withTimestamp(fakedDate)
+    .withMessageKey('domain.error.upload-error')
+    .withType('upload-error')
+    .build()
+
+  // States
+  const state1: AppState = {
+    file: {
+      byId: OrderedMap<string, FileEntity>(),
+      byType: OrderedMap<string, OrderedSet<string>>()
+    }
+  }
+  const state2: AppState = {
+    file: {
+      byId: OrderedMap<string, FileEntity>().set(file1.id, file1).set(file2.id, file2),
+      byType: OrderedMap<string, OrderedSet<string>>().set(
+        file1.type,
+        OrderedSet<string>([file1.id, file2.id])
+      )
+    }
+  }
+  const state3: AppState = {
+    file: {
+      byId: OrderedMap<string, FileEntity>().set(file1.id, file1),
+      byType: OrderedMap<string, OrderedSet<string>>().set(
+        file1.type,
+        OrderedSet<string>([file1.id])
+      )
+    }
+  }
+
+  // Event paramaters expects
+  const getExpectedEventParametersWithError = (error: Error) => [
+    getExpectedEventParameter('error/errorThrown', error, initiator, fakedDate)
+  ]
+
+  const getCombinedExpectedEventParametersWithError = (error: Error) => [
+    getExpectedEventParameter('task/taskRegisterReceived', taskToRegister1, initiator, fakedDate),
+    getExpectedEventParameter(
+      'task/taskStatusAmendReceived',
+      taskStatusToAmend1,
+      initiator,
+      fakedDate
+    ),
+    getExpectedEventParametersWithError(error)[0]
+  ]
+
+  const expectedEventParameters1 = [
+    getExpectedEventParameter('task/taskRegisterReceived', taskToRegister1, initiator, fakedDate),
+    getExpectedEventParameter(
+      'task/taskProgressValueSetReceived',
+      taskProgressValueToSet1,
+      initiator,
+      fakedDate
+    ),
+    getExpectedEventParameter(
+      'task/taskStatusAmendReceived',
+      taskStatusToAmend2,
+      initiator,
+      fakedDate
+    )
+  ]
+
+  beforeAll(() => {
+    short.generate = jest.fn(() => fakedUuid as short.SUUID)
+  })
+
+  describe.each`
+    hasUploadError | hasUnspecifiedError | clearFileRegistryGateway | filesToUpload     | preloadedState | expectedState | expectedEventParameters
+    ${false}       | ${false}            | ${false}                 | ${filesToUpload1} | ${state2}      | ${state1}     | ${getExpectedEventParametersWithError(unspecifiedError)}
+    ${false}       | ${false}            | ${false}                 | ${filesToUpload2} | ${state2}      | ${state1}     | ${getExpectedEventParametersWithError(unspecifiedError)}
+    ${false}       | ${false}            | ${false}                 | ${filesToUpload3} | ${state1}      | ${state1}     | ${getExpectedEventParametersWithError(unspecifiedError)}
+    ${true}        | ${false}            | ${false}                 | ${filesToUpload3} | ${state3}      | ${state1}     | ${getCombinedExpectedEventParametersWithError(uploadError)}
+    ${false}       | ${true}             | ${false}                 | ${filesToUpload3} | ${state3}      | ${state1}     | ${getCombinedExpectedEventParametersWithError(unspecifiedError)}
+    ${false}       | ${false}            | ${true}                  | ${filesToUpload3} | ${state2}      | ${state1}     | ${getExpectedEventParametersWithError(gatewayError)}
+    ${false}       | ${false}            | ${false}                 | ${filesToUpload3} | ${state3}      | ${state1}     | ${expectedEventParameters1}
+    ${false}       | ${false}            | ${false}                 | ${filesToUpload4} | ${state3}      | ${state1}     | ${expectedEventParameters1}
+  `(
+    'Given that ',
+    ({
+      hasUploadError,
+      hasUnspecifiedError,
+      clearFileRegistryGateway,
+      filesToUpload,
+      preloadedState,
+      expectedState,
+      expectedEventParameters
+    }: Readonly<Data>): void => {
+      const { store, fileGateway, fileRegistryGateway }: InitialProps = init(preloadedState)
+      hasUploadError && fileGateway.setUploadError()
+      hasUnspecifiedError && fileGateway.setUnspecifiedError()
+      clearFileRegistryGateway && fileRegistryGateway.clear()
+      describe('When uploading files', () => {
+        afterAll(() => {
+          jest.clearAllMocks()
+        })
+        test('Then, ', async () => {
+          await store.dispatch(uploadFiles(filesToUpload))
+          expect(store.getState()).toStrictEqual(expectedState)
+          cleanErrorStack(mockedEventBusPublish)
+          expectEventParameters<
+            | TaskRegisterReceivedPayload
+            | TaskStatusAmendReceivedPayload
+            | TaskProgressValueSetReceivedPayload
+          >(expectedEventParameters, mockedEventBusPublish)
+        })
+      })
+    }
+  )
+})

--- a/src/domain/file/usecase/upload-files/uploadFiles.ts
+++ b/src/domain/file/usecase/upload-files/uploadFiles.ts
@@ -1,0 +1,143 @@
+import short from 'short-uuid'
+import type { ReduxStore, ThunkResult } from 'domain/file/store/store'
+import type { UploadFiles } from 'domain/file/command/uploadFiles'
+import type { FileExecutorHandler, FilePort } from 'domain/file/port/filePort'
+import type { DeepReadonly } from 'superTypes'
+import type { FileEntity } from 'domain/file/entity/file'
+import { ErrorMapper } from 'domain/error/mapper/error.mapper'
+import { ThrowErrorActions } from 'domain/common/actionCreators'
+import { UnspecifiedError, UploadError } from 'domain/file/entity/error'
+import type { AppState } from 'domain/file/store/appState'
+import { removeAllFiles } from '../remove-all-files/removeAllFiles'
+import type { TaskRegisterReceivedPayload } from 'domain/task/event/taskRegisterReceived'
+import { RegisterTaskActions } from 'domain/task/usecase/register-task/actionCreators'
+import { getFilesSizeByIds } from 'domain/file/store/selector/file.selector'
+import { AmendTaskStatusActions } from 'domain/task/usecase/amend-task-status/actionCreators'
+import { SetTaskProgressValueActions } from 'domain/task/usecase/set-task-progress-value/actionCreators'
+import { truthy } from 'utils'
+
+const fileTaskType = 'file#upload-files'
+
+type StoreParams = { state: AppState; dispatch: ReduxStore['dispatch'] }
+
+const dispatchError = (error: unknown, dispatch: DeepReadonly<StoreParams['dispatch']>): void => {
+  const errorToDispatch = ErrorMapper.mapRawErrorToEntity(error)
+  dispatch(ThrowErrorActions.errorThrown(errorToDispatch))
+  dispatch(removeAllFiles())
+}
+
+const dispatchProgressCurrentValue =
+  (taskId: string, dispatch: DeepReadonly<StoreParams['dispatch']>) =>
+  (value?: number): void => {
+    value !== undefined &&
+      dispatch(
+        SetTaskProgressValueActions.taskProgressValueSetReceived({
+          id: taskId,
+          progressValue: value
+        })
+      )
+  }
+
+const executeGatewayUpload = async (
+  file: FileEntity,
+  target: string,
+  fileGateway: FilePort,
+  taskId: string,
+  dispatch: DeepReadonly<StoreParams['dispatch']>
+): Promise<void> => {
+  try {
+    await fileGateway.execute(async (handler: DeepReadonly<FileExecutorHandler>) => {
+      const { id, name, size, stream, type }: FileEntity = file
+
+      await handler.upload(
+        { id, name, size, stream, type },
+        target,
+        dispatchProgressCurrentValue(taskId, dispatch)
+      )
+    })
+
+    dispatch(AmendTaskStatusActions.taskStatusAmendReceived({ id: taskId, status: 'success' }))
+  } catch (error: unknown) {
+    const uploadError =
+      error instanceof UploadError
+        ? new UploadError(error.message, { ...error.context, taskId })
+        : new UnspecifiedError(
+            `Oops... An unspecified error occured when trying to execute a file upload for the task <${taskId}>`
+          )
+    dispatch(AmendTaskStatusActions.taskStatusAmendReceived({ id: taskId, status: 'error' }))
+    throw uploadError
+  }
+}
+
+const processUpload = async (
+  files: DeepReadonly<FileEntity<string>[]>,
+  target: string,
+  fileGateway: FilePort,
+  storeParams: DeepReadonly<StoreParams>
+): Promise<void[]> => {
+  const promises: Promise<void>[] = []
+  const { state, dispatch }: StoreParams = storeParams
+
+  files.forEach((file: FileEntity) => {
+    const taskToRegister: TaskRegisterReceivedPayload = {
+      id: short.generate(),
+      type: fileTaskType,
+      progress: {
+        min: 0,
+        max: getFilesSizeByIds(state, [file.id]),
+        current: 0
+      }
+    }
+    dispatch(RegisterTaskActions.taskRegisterReceived(taskToRegister))
+    promises.push(executeGatewayUpload(file, target, fileGateway, taskToRegister.id, dispatch))
+  })
+
+  return Promise.all(promises)
+}
+
+/**
+ * Upload files to any server.
+ * @param uploadFilesPayload An object containing the id of the file gateway to use,
+ * the target represented by either a root folder / bucket / etc. in which the file must be uploaded on server,
+ * and optionally an array of file ids to be uploaded.
+ * @return A Redux async ThunkResult.
+ */
+export const uploadFiles =
+  (uploadFilesPayload: DeepReadonly<UploadFiles>): ThunkResult<Promise<void>> =>
+  // eslint-disable-next-line @typescript-eslint/typedef
+  async (dispatch, getState, { fileRegistryGateway }) => {
+    try {
+      const storeParams: StoreParams = { state: getState(), dispatch }
+      const { target, filePortId, fileIds = [] }: DeepReadonly<UploadFiles> = uploadFilesPayload
+      const fileEntitiesById = storeParams.state.file.byId
+      const hasFileIds = fileIds.length > 0
+      const fileGateway = fileRegistryGateway.get(filePortId)
+      const isCommandPayloadValid = fileIds.every((fileId: string) => fileEntitiesById.has(fileId))
+
+      if (!fileEntitiesById.size) {
+        throw new UnspecifiedError(`Oops... It looks like there are no file(s) to upload...`)
+      }
+
+      if (hasFileIds && !isCommandPayloadValid) {
+        throw new UnspecifiedError(
+          `Oops... At least one provided file id does not exist... Check the provided list: ${JSON.stringify(
+            fileIds
+          )}...`
+        )
+      }
+
+      if (!target.length) {
+        throw new UnspecifiedError(
+          `Oops... It seems that the provided target is empty... So we cannot perform a file upload...`
+        )
+      }
+
+      const files = hasFileIds
+        ? fileIds.map((id: string) => fileEntitiesById.get(id)).filter(truthy)
+        : fileEntitiesById.toIndexedSeq().toArray()
+      await processUpload(files, target, fileGateway, storeParams)
+      dispatch(removeAllFiles())
+    } catch (error: unknown) {
+      dispatchError(error, dispatch)
+    }
+  }

--- a/src/domain/file/usecase/upload-files/uploadFiles.ts
+++ b/src/domain/file/usecase/upload-files/uploadFiles.ts
@@ -91,14 +91,14 @@ const processUpload = async (
     dispatch(RegisterTaskActions.taskRegisterReceived(taskToRegister))
     promises.push(executeGatewayUpload(file, target, fileGateway, taskToRegister.id, dispatch))
   })
-
   return Promise.all(promises)
 }
 
 /**
  * Upload files to any server.
  * @param uploadFilesPayload An object containing the id of the file gateway to use,
- * the target represented by either a root folder / bucket / etc. in which the file must be uploaded on server,
+ * the target represented by either a root folder / bucket / etc. in which the file must be uploaded
+ * on server (e.g 'MyBucketName' or '/rootFolderPath/'),
  * and optionally an array of file ids to be uploaded.
  * @return A Redux async ThunkResult.
  */

--- a/src/domain/task/event/taskProgressValueSetReceived.ts
+++ b/src/domain/task/event/taskProgressValueSetReceived.ts
@@ -1,0 +1,4 @@
+export type TaskProgressValueSetReceivedPayload<I = string> = {
+  readonly id: I
+  readonly progressValue: number
+}

--- a/src/domain/task/event/taskRegisterReceived.ts
+++ b/src/domain/task/event/taskRegisterReceived.ts
@@ -1,4 +1,7 @@
+import type { Progress } from './type'
+
 export type TaskRegisterReceivedPayload<T = string, I = string> = {
   readonly id: I
   readonly type: T
+  readonly progress?: Progress
 }

--- a/src/domain/task/store/selector/task.selector.spec.ts
+++ b/src/domain/task/store/selector/task.selector.spec.ts
@@ -5,7 +5,7 @@ import type { AppState } from '../../store/appState'
 import {
   getTaskStatusById,
   getTaskIdsByType,
-  getDisplayedTaskIdByTypeAndStatus
+  getDisplayedTaskIdsByTypeAndStatus
 } from './task.selector'
 import type { DeepReadonly } from 'superTypes'
 import { TaskBuilder } from 'domain/task/builder/task.builder'
@@ -18,7 +18,7 @@ type Data = DeepReadonly<{
   taskStatus: TaskStatus
   expectedTaskStatus: ReturnType<typeof getTaskStatusById>
   expectedTaskIds: ReturnType<typeof getTaskIdsByType>
-  exptectedDisplayedTaskIdByTypeAndStatus: ReturnType<typeof getDisplayedTaskIdByTypeAndStatus>
+  exptectedDisplayedTaskIdsByTypeAndStatus: ReturnType<typeof getDisplayedTaskIdsByTypeAndStatus>
 }>
 
 const aDate = new Date(1995, 11, 17)
@@ -36,7 +36,7 @@ const task2 = new TaskBuilder()
   .withCreationDate(bDate)
   .withLastUpdateDate(bDate)
   .withType('foo')
-  .withStatus('success')
+  .withStatus('error')
   .withInitiator('domain:test')
   .build()
 const task3 = new TaskBuilder()
@@ -59,10 +59,10 @@ const state1: AppState = {
 }
 
 describe.each`
-  state        | taskId          | taskType         | taskStatus         | expectedTaskStatus | expectedTaskIds                             | exptectedDisplayedTaskIdByTypeAndStatus
-  ${undefined} | ${'#id-1'}      | ${undefined}     | ${undefined}       | ${undefined}       | ${undefined}                                | ${undefined}
-  ${state1}    | ${'#id-broken'} | ${'broken-type'} | ${'broken-status'} | ${undefined}       | ${undefined}                                | ${undefined}
-  ${state1}    | ${'#id-3'}      | ${'foo'}         | ${'success'}       | ${task3.status}    | ${OrderedSet<string>([task1.id, task2.id])} | ${task1.id}
+  state        | taskId          | taskType         | taskStatus         | expectedTaskStatus | expectedTaskIds                             | exptectedDisplayedTaskIdsByTypeAndStatus
+  ${undefined} | ${'#id-1'}      | ${undefined}     | ${undefined}       | ${undefined}       | ${undefined}                                | ${[]}
+  ${state1}    | ${'#id-broken'} | ${'broken-type'} | ${'broken-status'} | ${undefined}       | ${undefined}                                | ${[]}
+  ${state1}    | ${'#id-3'}      | ${'foo'}         | ${'success'}       | ${task3.status}    | ${OrderedSet<string>([task1.id, task2.id])} | ${[task1.id]}
 `(
   'Given that state is <$state>, taskId is <$taskId>, taskType is <$taskType> and taskStatus is <$taskStatus>',
   ({
@@ -72,7 +72,7 @@ describe.each`
     taskStatus,
     expectedTaskStatus,
     expectedTaskIds,
-    exptectedDisplayedTaskIdByTypeAndStatus
+    exptectedDisplayedTaskIdsByTypeAndStatus: exptectedDisplayedTaskIdByTypeAndStatus
   }: Data): void => {
     const store = () => {
       const eventBusInstance = new EventBus()
@@ -99,7 +99,7 @@ describe.each`
     })
 
     describe('When performing selection getDisplayedTaskIdsByTypeAndStatus', () => {
-      const v = getDisplayedTaskIdByTypeAndStatus(store().getState(), taskType, taskStatus)
+      const v = getDisplayedTaskIdsByTypeAndStatus(store().getState(), taskType, taskStatus)
 
       test(`Then, expect value to be ${exptectedDisplayedTaskIdByTypeAndStatus}`, () => {
         expect(v).toEqual(exptectedDisplayedTaskIdByTypeAndStatus)

--- a/src/domain/task/store/selector/task.selector.ts
+++ b/src/domain/task/store/selector/task.selector.ts
@@ -27,12 +27,11 @@ export const getTaskIdsByType: (
   (tasks: DeepReadonly<TaskByType>, type: string) => tasks.get(type)
 )
 
-// Get only first displayed Id by a specified type and status
-export const getDisplayedTaskIdByTypeAndStatus: (
+export const getDisplayedTaskIdsByTypeAndStatus: (
   state: DeepReadonly<AppState>,
   type: string,
   status: Status
-) => string | undefined = createSelector(
+) => string[] = createSelector(
   [
     rootSelector,
     (state: DeepReadonly<AppState>, type: string): OrderedSet<string> | undefined =>
@@ -43,9 +42,10 @@ export const getDisplayedTaskIdByTypeAndStatus: (
     state: DeepReadonly<AppState>,
     taskIdsByType: DeepReadonly<OrderedSet<string> | undefined>,
     status: Status
-  ): string | undefined =>
-    state.displayedTaskIds.find(
-      (id: string) =>
-        (taskIdsByType?.includes(id) && getTaskStatusById(state, id) === status) ?? false
-    )
+  ): string[] =>
+    state.displayedTaskIds
+      .toArray()
+      .filter(
+        (id: string) => taskIdsByType?.includes(id) && getTaskStatusById(state, id) === status
+      )
 )

--- a/src/domain/task/usecase/set-task-progress-value/actionCreators.ts
+++ b/src/domain/task/usecase/set-task-progress-value/actionCreators.ts
@@ -2,11 +2,14 @@
 import type { ActionsUnion } from 'domain/common/store.helper'
 import { createAction } from 'domain/common/store.helper'
 import type { TaskProgressValueSetPayload } from 'domain/task/event/taskProgressValueSet'
+import type { TaskProgressValueSetReceivedPayload } from 'domain/task/event/taskProgressValueSetReceived'
 import type { DeepReadonly } from 'superTypes'
 
 export const SetTaskProgressValueActions = {
   taskProgressValueSet: (payload: DeepReadonly<TaskProgressValueSetPayload>) =>
-    createAction('task/taskProgressValueSet', payload)
+    createAction('task/taskProgressValueSet', payload),
+  taskProgressValueSetReceived: (payload: DeepReadonly<TaskProgressValueSetReceivedPayload>) =>
+    createAction('task/taskProgressValueSetReceived', payload)
 }
 
 export type SetTaskProgressValueActionTypes = ActionsUnion<typeof SetTaskProgressValueActions>

--- a/src/ui/organisms/faucet/Faucet.tsx
+++ b/src/ui/organisms/faucet/Faucet.tsx
@@ -14,7 +14,7 @@ import { useWalletDispatch } from 'hook/storeHook/walletHook'
 import { useTranslation } from 'hook/useTranslation'
 import type { UseTranslationResponse } from 'hook/useTranslation'
 import { hasUnseenError, unseenErrorMessage } from 'domain/error/store/selector/error.selector'
-import { getDisplayedTaskIdByTypeAndStatus } from 'domain/task/store/selector/task.selector'
+import { getDisplayedTaskIdsByTypeAndStatus } from 'domain/task/store/selector/task.selector'
 import { Button } from 'ui/atoms/button/Button'
 import { TextField } from 'ui/atoms/textField/TextField'
 import { Toast } from 'ui/atoms/toast/Toast'
@@ -42,11 +42,13 @@ export const Faucet: React.FC<FaucetProps> = ({ chainId }: FaucetProps) => {
   const address = useFaucetSelector((state: DeepReadonly<FaucetAppState>) => state.address)
   const hasTransactionError = useErrorSelector(hasUnseenError)
   const errorMessage = useErrorSelector(unseenErrorMessage)
-  const transactionSuccessId = useTaskSelector((state: DeepReadonly<TaskAppState>) =>
-    getDisplayedTaskIdByTypeAndStatus(state, faucetTaskType, 'success')
+  const transactionSuccessId = useTaskSelector(
+    (state: DeepReadonly<TaskAppState>) =>
+      getDisplayedTaskIdsByTypeAndStatus(state, faucetTaskType, 'success')[0]
   )
-  const transactionLoading = useTaskSelector((state: DeepReadonly<TaskAppState>) =>
-    getDisplayedTaskIdByTypeAndStatus(state, faucetTaskType, 'processing')
+  const transactionLoading = useTaskSelector(
+    (state: DeepReadonly<TaskAppState>) =>
+      getDisplayedTaskIdsByTypeAndStatus(state, faucetTaskType, 'processing')[0]
   )
 
   const acknowledgeFaucetError = useCallback(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,900 @@
     signedsource "^1.0.0"
     yargs "^15.3.1"
 
+"@aws-crypto/crc32@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-2.0.0.tgz#4ad432a3c03ec3087c5540ff6e41e6565d2dc153"
+  integrity sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==
+  dependencies:
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/crc32c@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz#4235336ef78f169f6a05248906703b9b78da676e"
+  integrity sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==
+  dependencies:
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/ie11-detection@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz#9c39f4a5558196636031a933ec1b4792de959d6a"
+  integrity sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/sha1-browser@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz#71e735df20ea1d38f59259c4b1a2e00ca74a0eea"
+  integrity sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==
+  dependencies:
+    "@aws-crypto/ie11-detection" "^2.0.0"
+    "@aws-crypto/supports-web-crypto" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-browser@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz#741c9024df55ec59b51e5b1f5d806a4852699fb5"
+  integrity sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==
+  dependencies:
+    "@aws-crypto/ie11-detection" "^2.0.0"
+    "@aws-crypto/sha256-js" "^2.0.0"
+    "@aws-crypto/supports-web-crypto" "^2.0.0"
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    "@aws-sdk/util-locate-window" "^3.0.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-js@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz#f1f936039bdebd0b9e2dd834d65afdc2aac4efcb"
+  integrity sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==
+  dependencies:
+    "@aws-crypto/util" "^2.0.0"
+    "@aws-sdk/types" "^3.1.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/sha256-js@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-2.0.2.tgz#c81e5d378b8a74ff1671b58632779986e50f4c99"
+  integrity sha512-iXLdKH19qPmIC73fVCrHWCSYjN/sxaAvZ3jNNyw6FclmHyjLKg0f69WlC9KTnyElxCR5MO9SKaG00VwlJwyAkQ==
+  dependencies:
+    "@aws-crypto/util" "^2.0.2"
+    "@aws-sdk/types" "^3.110.0"
+    tslib "^1.11.1"
+
+"@aws-crypto/supports-web-crypto@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz#9f02aafad8789cac9c0ab5faaebb1ab8aa841338"
+  integrity sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==
+  dependencies:
+    tslib "^1.11.1"
+
+"@aws-crypto/util@^2.0.0", "@aws-crypto/util@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-2.0.2.tgz#adf5ff5dfbc7713082f897f1d01e551ce0edb9c0"
+  integrity sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==
+  dependencies:
+    "@aws-sdk/types" "^3.110.0"
+    "@aws-sdk/util-utf8-browser" "^3.0.0"
+    tslib "^1.11.1"
+
+"@aws-sdk/abort-controller@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/abort-controller/-/abort-controller-3.171.0.tgz#d003aa8cb30b6de4a23ae5f1fc0e5a7ebc79e6c4"
+  integrity sha512-D3ShqAdCSFvKN3pGGn0KwK6lece4nqKY0hrxMIaYvDwewGjoIgEMBPGhCK1kNoBo6lJ93Fu1u4DheV+8abSmjQ==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/chunked-blob-reader-native@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.170.0.tgz#a277f4aec88246c6de69d4f15e5fd5e262f0ac6b"
+  integrity sha512-haJ7fdWaOgAM4trw2LBd1VIvRFzMMPz2jy9mu4rE+z1uHbPZHNMGytBo1FJO2DShzUCmJZi3t3CD/7aE3H38+w==
+  dependencies:
+    "@aws-sdk/util-base64-browser" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/chunked-blob-reader@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.170.0.tgz#059fd50c8ed7ddc9219f483258ec3a0cab6ca699"
+  integrity sha512-73Fy1u9zR9ZMC59QobuCWg3LoYfcrFsrP8569vvqtlGqPuQUW+RW3gfx0omIDmxaSg8qq8REPLJFrAGfeL7VtQ==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/client-s3@^3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.171.0.tgz#d77275ecc4d9e40cbd207e164bb9c18c836629e4"
+  integrity sha512-UFPnf9xG7H6Mku9tfVH7oSXq65oH0mb8vvfeUWsi+KKedvMdww7fVWmXtcgnsB9nmXLF2PfrQrdaz2uid4rpgQ==
+  dependencies:
+    "@aws-crypto/sha1-browser" "2.0.0"
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/client-sts" "3.171.0"
+    "@aws-sdk/config-resolver" "3.171.0"
+    "@aws-sdk/credential-provider-node" "3.171.0"
+    "@aws-sdk/eventstream-serde-browser" "3.171.0"
+    "@aws-sdk/eventstream-serde-config-resolver" "3.171.0"
+    "@aws-sdk/eventstream-serde-node" "3.171.0"
+    "@aws-sdk/fetch-http-handler" "3.171.0"
+    "@aws-sdk/hash-blob-browser" "3.171.0"
+    "@aws-sdk/hash-node" "3.171.0"
+    "@aws-sdk/hash-stream-node" "3.171.0"
+    "@aws-sdk/invalid-dependency" "3.171.0"
+    "@aws-sdk/md5-js" "3.171.0"
+    "@aws-sdk/middleware-bucket-endpoint" "3.171.0"
+    "@aws-sdk/middleware-content-length" "3.171.0"
+    "@aws-sdk/middleware-expect-continue" "3.171.0"
+    "@aws-sdk/middleware-flexible-checksums" "3.171.0"
+    "@aws-sdk/middleware-host-header" "3.171.0"
+    "@aws-sdk/middleware-location-constraint" "3.171.0"
+    "@aws-sdk/middleware-logger" "3.171.0"
+    "@aws-sdk/middleware-recursion-detection" "3.171.0"
+    "@aws-sdk/middleware-retry" "3.171.0"
+    "@aws-sdk/middleware-sdk-s3" "3.171.0"
+    "@aws-sdk/middleware-serde" "3.171.0"
+    "@aws-sdk/middleware-signing" "3.171.0"
+    "@aws-sdk/middleware-ssec" "3.171.0"
+    "@aws-sdk/middleware-stack" "3.171.0"
+    "@aws-sdk/middleware-user-agent" "3.171.0"
+    "@aws-sdk/node-config-provider" "3.171.0"
+    "@aws-sdk/node-http-handler" "3.171.0"
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/signature-v4-multi-region" "3.171.0"
+    "@aws-sdk/smithy-client" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/url-parser" "3.171.0"
+    "@aws-sdk/util-base64-browser" "3.170.0"
+    "@aws-sdk/util-base64-node" "3.170.0"
+    "@aws-sdk/util-body-length-browser" "3.170.0"
+    "@aws-sdk/util-body-length-node" "3.170.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.171.0"
+    "@aws-sdk/util-defaults-mode-node" "3.171.0"
+    "@aws-sdk/util-stream-browser" "3.171.0"
+    "@aws-sdk/util-stream-node" "3.171.0"
+    "@aws-sdk/util-user-agent-browser" "3.171.0"
+    "@aws-sdk/util-user-agent-node" "3.171.0"
+    "@aws-sdk/util-utf8-browser" "3.170.0"
+    "@aws-sdk/util-utf8-node" "3.170.0"
+    "@aws-sdk/util-waiter" "3.171.0"
+    "@aws-sdk/xml-builder" "3.170.0"
+    entities "2.2.0"
+    fast-xml-parser "3.19.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sso@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.171.0.tgz#a2b01816dfafeeb051768f38913c6224c3708e36"
+  integrity sha512-iOJxoxHFlyuGfXKVz8Z7xVgYkdnqw6beDpIO852aDL6DYFO0ZA6vYjWXsMgdY6S6zJOR2K2uRhvPpbPiFF5PtA==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.171.0"
+    "@aws-sdk/fetch-http-handler" "3.171.0"
+    "@aws-sdk/hash-node" "3.171.0"
+    "@aws-sdk/invalid-dependency" "3.171.0"
+    "@aws-sdk/middleware-content-length" "3.171.0"
+    "@aws-sdk/middleware-host-header" "3.171.0"
+    "@aws-sdk/middleware-logger" "3.171.0"
+    "@aws-sdk/middleware-recursion-detection" "3.171.0"
+    "@aws-sdk/middleware-retry" "3.171.0"
+    "@aws-sdk/middleware-serde" "3.171.0"
+    "@aws-sdk/middleware-stack" "3.171.0"
+    "@aws-sdk/middleware-user-agent" "3.171.0"
+    "@aws-sdk/node-config-provider" "3.171.0"
+    "@aws-sdk/node-http-handler" "3.171.0"
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/smithy-client" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/url-parser" "3.171.0"
+    "@aws-sdk/util-base64-browser" "3.170.0"
+    "@aws-sdk/util-base64-node" "3.170.0"
+    "@aws-sdk/util-body-length-browser" "3.170.0"
+    "@aws-sdk/util-body-length-node" "3.170.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.171.0"
+    "@aws-sdk/util-defaults-mode-node" "3.171.0"
+    "@aws-sdk/util-user-agent-browser" "3.171.0"
+    "@aws-sdk/util-user-agent-node" "3.171.0"
+    "@aws-sdk/util-utf8-browser" "3.170.0"
+    "@aws-sdk/util-utf8-node" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/client-sts@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.171.0.tgz#583b94cd74afef2b9b1d9e149c339e5d11e519c6"
+  integrity sha512-CozT5qq/Wtdn4CDz5PdXtdyGnzHbuLqOYcTgaYpDks2EPfRSSFT2WYE+Y76Ccdz5n7vWR3yJuNjDXnVL28U8gQ==
+  dependencies:
+    "@aws-crypto/sha256-browser" "2.0.0"
+    "@aws-crypto/sha256-js" "2.0.0"
+    "@aws-sdk/config-resolver" "3.171.0"
+    "@aws-sdk/credential-provider-node" "3.171.0"
+    "@aws-sdk/fetch-http-handler" "3.171.0"
+    "@aws-sdk/hash-node" "3.171.0"
+    "@aws-sdk/invalid-dependency" "3.171.0"
+    "@aws-sdk/middleware-content-length" "3.171.0"
+    "@aws-sdk/middleware-host-header" "3.171.0"
+    "@aws-sdk/middleware-logger" "3.171.0"
+    "@aws-sdk/middleware-recursion-detection" "3.171.0"
+    "@aws-sdk/middleware-retry" "3.171.0"
+    "@aws-sdk/middleware-sdk-sts" "3.171.0"
+    "@aws-sdk/middleware-serde" "3.171.0"
+    "@aws-sdk/middleware-signing" "3.171.0"
+    "@aws-sdk/middleware-stack" "3.171.0"
+    "@aws-sdk/middleware-user-agent" "3.171.0"
+    "@aws-sdk/node-config-provider" "3.171.0"
+    "@aws-sdk/node-http-handler" "3.171.0"
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/smithy-client" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/url-parser" "3.171.0"
+    "@aws-sdk/util-base64-browser" "3.170.0"
+    "@aws-sdk/util-base64-node" "3.170.0"
+    "@aws-sdk/util-body-length-browser" "3.170.0"
+    "@aws-sdk/util-body-length-node" "3.170.0"
+    "@aws-sdk/util-defaults-mode-browser" "3.171.0"
+    "@aws-sdk/util-defaults-mode-node" "3.171.0"
+    "@aws-sdk/util-user-agent-browser" "3.171.0"
+    "@aws-sdk/util-user-agent-node" "3.171.0"
+    "@aws-sdk/util-utf8-browser" "3.170.0"
+    "@aws-sdk/util-utf8-node" "3.170.0"
+    entities "2.2.0"
+    fast-xml-parser "3.19.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/config-resolver@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/config-resolver/-/config-resolver-3.171.0.tgz#54df47465f541633d0555104b4db59be9cc5e21f"
+  integrity sha512-qxuquXxy2Uu96Vmm5lm3b72wx8g+7XkWf5pGeQPPgXT4Zrw6UQdtqvNhsoFpKLp/Op1yu/CIDd7lG2l1Xgs5HQ==
+  dependencies:
+    "@aws-sdk/signature-v4" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/util-config-provider" "3.170.0"
+    "@aws-sdk/util-middleware" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-env@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.171.0.tgz#53ca9f39a97cc53b61126382a8b023afdc8dcd46"
+  integrity sha512-Btm7mu+2RsOQxplGhHMKat+CgaOHwpqt1j3aU2EQtad5Fb5NSZRD85mqD/BGCCLTmfqIWl39YQv9758gciRjCw==
+  dependencies:
+    "@aws-sdk/property-provider" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-imds@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.171.0.tgz#4276c79494dcc6143bbd118ab9074f8beacbaa8c"
+  integrity sha512-lm5uuJ3YK6qui7G6Zr5farUuHn10kMtkb+CFr4gtDsYxF8CscciBmQNMCxo2oiVzlsjOpFGtpLTAvjb7nn12CA==
+  dependencies:
+    "@aws-sdk/node-config-provider" "3.171.0"
+    "@aws-sdk/property-provider" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/url-parser" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-ini@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.171.0.tgz#dd57dd21183e806526c0cf7ce2a044c9bd9b213b"
+  integrity sha512-MF6fYCvezreZBI+hjI4oEuZdIKgfhbe6jzbTpNrDwBzw8lBkq1UY214dp2ecJtnj3FKjFg9A+goQRa/CViNgGQ==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.171.0"
+    "@aws-sdk/credential-provider-imds" "3.171.0"
+    "@aws-sdk/credential-provider-sso" "3.171.0"
+    "@aws-sdk/credential-provider-web-identity" "3.171.0"
+    "@aws-sdk/property-provider" "3.171.0"
+    "@aws-sdk/shared-ini-file-loader" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-node@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.171.0.tgz#dffc480a87105828bd75e5c0158e3e1da0267acb"
+  integrity sha512-zUdgr9THjzLb99Qmb1qOqsSYtX4/PCCzXgDolfYS/+bLfoMD1iqA49l6lw4zJV29f6WNjaA5MxmDpbrPXkI1Cw==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.171.0"
+    "@aws-sdk/credential-provider-imds" "3.171.0"
+    "@aws-sdk/credential-provider-ini" "3.171.0"
+    "@aws-sdk/credential-provider-process" "3.171.0"
+    "@aws-sdk/credential-provider-sso" "3.171.0"
+    "@aws-sdk/credential-provider-web-identity" "3.171.0"
+    "@aws-sdk/property-provider" "3.171.0"
+    "@aws-sdk/shared-ini-file-loader" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-process@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.171.0.tgz#3b207fa9d6b69e8e4f731633c16fa2cd32549923"
+  integrity sha512-wTrtftwepuW+yJG2mz+HDwQ/L70rwBPkeyy32X+Pfm1jh4B5lL3qMmxR7uLPMgA4BQfXCazPeOiW50b9wRyZYg==
+  dependencies:
+    "@aws-sdk/property-provider" "3.171.0"
+    "@aws-sdk/shared-ini-file-loader" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-sso@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.171.0.tgz#515bc31e9fb2a171b512391002912167a7c83f07"
+  integrity sha512-D1zyKiYL9jrzJz5VOKynAAxqyQZ5gjweRPNrIomrYG2BQSMz82CZzL/sn/Q2KNmuSWgfPc4bF2JDPeTdPXsFKA==
+  dependencies:
+    "@aws-sdk/client-sso" "3.171.0"
+    "@aws-sdk/property-provider" "3.171.0"
+    "@aws-sdk/shared-ini-file-loader" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/credential-provider-web-identity@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.171.0.tgz#d1023bc0a6c057228b00ccdcde2b1c19136e2be5"
+  integrity sha512-yeQC+n3Xiw/tOaMP67pBNLsddPb8hHjsEIPircS2z4VvwhOY+5ZaaiaRmw5u5pvIMctbGZU75Ms1hBSfOEdDhQ==
+  dependencies:
+    "@aws-sdk/property-provider" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-codec@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-codec/-/eventstream-codec-3.171.0.tgz#4f8a9537a5b9633f95cc03b367400d7c7b860f8f"
+  integrity sha512-3lCnPlydbZ/R6fAD+4xLX8Ua+kFGUzsPcgLP0lH5LO39jtnN1wEQj5fWM139Re9LuD0NoEBhC0AuROIM6CbzVA==
+  dependencies:
+    "@aws-crypto/crc32" "2.0.0"
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/util-hex-encoding" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-serde-browser@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.171.0.tgz#3fe9ba09078e32e687ccb4b649c304dc3c80912e"
+  integrity sha512-ydjENlRoX49odSCWsOUo2lP2yE/4dR/GKE1yz3QvNZJ+6wRULbg6f55riyQokvAGMRW5BJigkMQLrg58WWridg==
+  dependencies:
+    "@aws-sdk/eventstream-serde-universal" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-serde-config-resolver@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.171.0.tgz#451e6fa1c5f1b8a8123eecbd1f225405581ea75c"
+  integrity sha512-cg+Xzl1lB7iIcER+Pv/06VaBvlC/dZxs3i5Kw3PYUaYICDwGytGRZbEC2H/6aBDEYYLfwUbnkq0Dp40faJfdAw==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-serde-node@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.171.0.tgz#2da5283fc890b8ce7b4bfd2dd3907da51c5ea656"
+  integrity sha512-psOYj2RUJsI14jHCw1FQdSTljaf0yE9svg5NY9mGFD1ifj5+XEZmxhADMA6wtnDjWS2MzyJQQUGdfqIv1FeHEQ==
+  dependencies:
+    "@aws-sdk/eventstream-serde-universal" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/eventstream-serde-universal@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.171.0.tgz#050d5e33942b59c4708a9a5ced75978a069b7c31"
+  integrity sha512-aItTLL+WDHgwvl0biGZ+9phUOH93RW/v4uZgvjmrGSUx6try2/+L1rQeLU9n7JYfGcu8CKNePxpvrfSXpgJ7FA==
+  dependencies:
+    "@aws-sdk/eventstream-codec" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/fetch-http-handler@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.171.0.tgz#d7e1917f01885db9137a6996ae316918bb11eda2"
+  integrity sha512-jxlY0WFBrd5QzXnPNmzq8LbcIN3iY4Di+b9nDlUkQ6yCp/PxBEO3iZiNk4DeMH4A6rHrksnbsDDJzzZyGw/TLg==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/querystring-builder" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/util-base64-browser" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/hash-blob-browser@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.171.0.tgz#76c2815e4b42ae83936209e3adb78c0010dd4151"
+  integrity sha512-Orwm8OiVNlVaQFEn+mWkue4U2bYytuAi5nmv9Co41hXDR8qF4pvwPWVV70OsndGcgqlFfvkJ4KahCO8Mta4I3w==
+  dependencies:
+    "@aws-sdk/chunked-blob-reader" "3.170.0"
+    "@aws-sdk/chunked-blob-reader-native" "3.170.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/hash-node@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-node/-/hash-node-3.171.0.tgz#f0f712cd380b6a4ad6e9f7ae282be97b2ee53455"
+  integrity sha512-eTn8iExc6KjMo3OLz29zkADq9hXsA1jO2ghQfQ4BNdGXvhMtKcIO2hdhyzaOhtoLAeL44gbFR9oFjwG0U8ak/Q==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/util-buffer-from" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/hash-stream-node@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/hash-stream-node/-/hash-stream-node-3.171.0.tgz#fd758cea9935fff82268c8c154bfe8e93ed4afb8"
+  integrity sha512-22yrj3Gx09n6esypHWSqqGTdKoMb/ORi55U4OtdCHufUtPVahwetNqKVBP73pHiT2VEmLQ8cyWff1WwpRFdeFw==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/invalid-dependency@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/invalid-dependency/-/invalid-dependency-3.171.0.tgz#25d605630e88c0d5dbc3afaf1941fb4973118e7c"
+  integrity sha512-UrjQnhRv2B6ZgQfZjRbsaD6Sm5aIjH9YPtjT5oTbSgq3uHnj+s2ubUYd2nR8+lV2j1XL/Zfn/zUQ+6W3Fxk+UA==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/is-array-buffer@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/is-array-buffer/-/is-array-buffer-3.170.0.tgz#a34b82b0d7c534544db001837785ed086d99344c"
+  integrity sha512-yYXqgp8rilBckIvNRs22yAXHKcXb86/g+F+hsTZl38OJintTsLQB//O5v6EQTYhSW7T3wMe1NHDrjZ+hFjAy4Q==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/lib-storage@^3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/lib-storage/-/lib-storage-3.171.0.tgz#cccbcfde7d696d2ea08ac9328f5b9ab2985bdca2"
+  integrity sha512-CGx1yt1WgGXuAdjGrY/ibsKoAWZvpI/lXxr9Vbsp80Ud035FKHOo/kfCGx2A9S1RltiAfsgpGk1KlF7O8OYX+g==
+  dependencies:
+    "@aws-sdk/smithy-client" "3.171.0"
+    buffer "5.6.0"
+    events "3.3.0"
+    stream-browserify "3.0.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/md5-js@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/md5-js/-/md5-js-3.171.0.tgz#b38ff2d83679dc0ad01462e42afc5faa3687b0dc"
+  integrity sha512-ZHuK7NvRY44WasjRjHnTNTGfdWuZTND4CCRC78Fmf3tk+zeCEnDZ81cVVtMqVn1wIf02U35Bwbunfx8i89VoSg==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/util-utf8-browser" "3.170.0"
+    "@aws-sdk/util-utf8-node" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-bucket-endpoint@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.171.0.tgz#59f6805e74246205ad19585ecc26bdb6e08b0f25"
+  integrity sha512-mRARZ8+WSoEfy4v5Gp084O2kxKwjoVozKQ0QN0BGYU//HKWwPRQ5qnv8Sty5oEA6J3rjYrqeIuFd6I8J/MxYZg==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/util-arn-parser" "3.170.0"
+    "@aws-sdk/util-config-provider" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-content-length@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-content-length/-/middleware-content-length-3.171.0.tgz#b9fd81390697ac2ebdbad93d30720c9736cac578"
+  integrity sha512-zvhCvoR36fxjygDA8yN3AAVFnL0i6ubLRvzq6gf6gHVJH2P7/IWkXOBwu461qpuHPG87QwdqB/W+qY3KfNu/mA==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-expect-continue@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.171.0.tgz#9e2733fc2389ebd7919029bbaa5283779ce5cc0f"
+  integrity sha512-Sc4onadPMH0JRfAT1CXf405aGUGktgCM+UyyX5f85rT/5J5omwt2d31vu0ri4CmU89QI5T7xeq4DN6mNQu2jfw==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-flexible-checksums@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.171.0.tgz#f31265f06019520eea7e49c0f1dbc298e5e40808"
+  integrity sha512-91GvgWCG/cugmxXlOWCKmynMoKsKzmdOBj01k7Vx0oZAeR8/3i74mpGQ6DRaaTOENNgFrcHzxnlxJDZEY44MOw==
+  dependencies:
+    "@aws-crypto/crc32" "2.0.0"
+    "@aws-crypto/crc32c" "2.0.0"
+    "@aws-sdk/is-array-buffer" "3.170.0"
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-host-header@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.171.0.tgz#e542b3dfc82608230a6ca81306254c72de8e58e3"
+  integrity sha512-WM3NEq1RcBOBXp2ItZCnK9RJPBztdUdaQrgtTkBWekgc9yxCiRBDhdZ4GLuWKyzApO2xqI/kfZQa4Wf44lWl8g==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-location-constraint@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.171.0.tgz#7c01b94b30d4043d6da2ffe76a95afb22e666a0b"
+  integrity sha512-fj/LH3mLVpK4lwB1DGcYflzfFllcXcYb+ZyGIVdZ0ZeXBOeG8sOG59C4ZdDK3XONnE+Ccv/s7l6MlXK6c9PDew==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-logger@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.171.0.tgz#7becde09154d674de7d0cc95b4fa123752798ef3"
+  integrity sha512-/wn0+pV0AGcDGlcKY+2ylvp+FLXJdmvYLbPlo93OOQbyCOy7Xa7Z8+RZYFHv8xrqhlQI0iw6TSYbL6fQ1v5IZw==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-recursion-detection@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.171.0.tgz#500fe96c97f2045f4196d041fd2f00e0d2af8547"
+  integrity sha512-aNDRypFz9V52hC8lzZo28Zq9pS7W2MchjLAa2mPTFTd09aer6j9jmLY5o4NwoAAaEGV1JFHgpIZdymQRAcvSjw==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-retry@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-retry/-/middleware-retry-3.171.0.tgz#e83bb0a8e57f0828a9b087e8d362a5bf29ffceef"
+  integrity sha512-E+TTJZngDZ91/pdlNSrYSKn2cjD0aL/Xe6VFKbhpt9k5EF/KK6gJUEitIFL3Db2bRqupgADQudUI+MZvNc7Bnw==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/service-error-classification" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/util-middleware" "3.171.0"
+    tslib "^2.3.1"
+    uuid "^8.3.2"
+
+"@aws-sdk/middleware-sdk-s3@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.171.0.tgz#d0ed1640e5ade047c5d637f8c9c95c66a35613ce"
+  integrity sha512-Mmd2MqJQJnYXrtOL01PgTXtH0MvubzGJ1uYAm0CLK2fubhLEp2usNACXFvUcdwd3dt5QktkLjWuw3xwFoIYGMg==
+  dependencies:
+    "@aws-sdk/middleware-bucket-endpoint" "3.171.0"
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/util-arn-parser" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-sdk-sts@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.171.0.tgz#44a64e814d1b59337a5c3f807dacd9fea1a881d2"
+  integrity sha512-DLvoz7TfExbJ1p+FGehbu83D/KggohQNZMzsIojVbzu3E0pO606aZnbEPC7pUNXG3iXoQOScMMrhUNuRQEYgLQ==
+  dependencies:
+    "@aws-sdk/middleware-signing" "3.171.0"
+    "@aws-sdk/property-provider" "3.171.0"
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/signature-v4" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-serde@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-serde/-/middleware-serde-3.171.0.tgz#225ee30538e73eff4be5eae6362b9101d628548d"
+  integrity sha512-eqgJPzzkha02Ca7clKWLOVOa7OuFunEPWfx00IUy5sxKFbgUSAeu6Kl5SC5Z3J9dIvefw3vX19x3334SZcwE1Q==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-signing@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-signing/-/middleware-signing-3.171.0.tgz#04a0b93240044e48190354a15fef6081023655c7"
+  integrity sha512-eEykO86etIqfWdUvvCcvYsHg+lXRE1Bo6+2mtXIcUXXC0LlqUoWsM1Ky/5jbjXVeWu2vWv++vG/WpJtNKkG13Q==
+  dependencies:
+    "@aws-sdk/property-provider" "3.171.0"
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/signature-v4" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-ssec@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-ssec/-/middleware-ssec-3.171.0.tgz#15ac51f38c6f063dbcbb626dccfafb5717d62a3d"
+  integrity sha512-lYf8gxe09owOUuvIil1G6TXQjUwIh7yuqeqj+Ix1aLbEZyloiryXkWjCPfeTEybVukWM0HPqU28AMhjgTOal6g==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-stack@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-stack/-/middleware-stack-3.171.0.tgz#ea5955bc7ce821785b30820411842a6f3037191c"
+  integrity sha512-0EbZin5J6EsHD/agE8s/TJktLh9aRZe80ZrCBv5ces420NaYNjvbvvsnt0tQw0Q8qv+1H6KFOUcZ5iXzadBy2A==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/middleware-user-agent@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.171.0.tgz#51b8b921d5f7518b2e668909c4a4add03bed6047"
+  integrity sha512-GXw4LB6OqmPNwizY8KHdP7sC+d3gVTeeTbMhLPdZ62+PTj18faSoiBtQbnQmB/+c87VBlYbXex2ObfB6J0K2rg==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/node-config-provider@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-config-provider/-/node-config-provider-3.171.0.tgz#a5f8cf56e1b1cc7b8e7ae840fa7d954e2ceb1b9d"
+  integrity sha512-kFJbdJpqV8qCrs0h5Yo1r9TgezzGlua8NYf80gx8gH49gDZ4hl+0gP7rWEnA19dZufrfveyTQ/kY+ntk5AyI8A==
+  dependencies:
+    "@aws-sdk/property-provider" "3.171.0"
+    "@aws-sdk/shared-ini-file-loader" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/node-http-handler@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/node-http-handler/-/node-http-handler-3.171.0.tgz#798b04d5af4f2c39d058f4c32336ad1e5a2ba05f"
+  integrity sha512-hQY1hqgVcNC9KvRqV3Kxn2jCjIgMWwK3u90g2kNU27vZWIApz5hP4Y/TiyFO3+fGGNczcNHZp8aaggEO9tnctQ==
+  dependencies:
+    "@aws-sdk/abort-controller" "3.171.0"
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/querystring-builder" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/property-provider@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/property-provider/-/property-provider-3.171.0.tgz#33bb16f6735eb6f6198fc527f61a516a063fd712"
+  integrity sha512-dtF9TfEuvYQCqyp5EbGLzwhGmxljDG95901STIRtOCbBi0EXQ2oShKz1T95kjaSrBQsI2YOmDTl+uPGkkOx5oA==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/protocol-http@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/protocol-http/-/protocol-http-3.171.0.tgz#345f2467172d68d12c215aae62146b16e3be6b4b"
+  integrity sha512-J5iZr5epH3nhPEeEme3w0l1tz+re1l9TdKjfaoczEmZyoChtHr++x/QX2KPxIn5NVSe7QxN7yTJV373NrnMMfg==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/querystring-builder@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-builder/-/querystring-builder-3.171.0.tgz#ea6f9722f97e0ddbee7017fb239d0284f7f0955f"
+  integrity sha512-qiDk3BlYH77QtJS6vSZlCGYjaW1Qq7JnxiAHPZc+wsl0kY59JPVuM5HTTZ+yjTu+hmSeiI0Wp5IHDiY+YOxi4w==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/util-uri-escape" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/querystring-parser@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/querystring-parser/-/querystring-parser-3.171.0.tgz#95c61cfd5e01c455fc9ad51a674539bacff256d1"
+  integrity sha512-wYM4HVlmi0NaRxJXmOPwQ4L6LPwUvRNMg+33z2Vvs9Ij23AzTCI2JRtaAwz/or3h6+nMlCOVsLZ7PAoLhkrgmg==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/service-error-classification@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/service-error-classification/-/service-error-classification-3.171.0.tgz#3d160314e5f37ed3f0245a970b30d1ab91da8a6d"
+  integrity sha512-OrVFyPh3fFACRvplp8YvSdKNIXNx8xNYsHK+WhJFVOwnLC6OkwMyjck1xjfu4gvQ/PZlLqn7qTTURKcI2rUbMw==
+
+"@aws-sdk/shared-ini-file-loader@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.171.0.tgz#5fd9d17d2058ce3798d29f99961bf7ba65df0c8c"
+  integrity sha512-tilea/YDqszMqXn3pOaBBZVSA/29MegV0QBhKlrJoYzhZxZ1ZrlkyuTUVz6RjktRUYnty9D3MlgrmaiBxAOdrg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/signature-v4-multi-region@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.171.0.tgz#378ba321a733e80ae013c51fc4c268aadac1d5e5"
+  integrity sha512-ga149Xf8uQ+e29gC+mRfdvDy4aOJidRE86YkZ0D6/XMBpmMl7dU9sKioKCKhPeUr10L7w4I3WRA1G3Vjq5j43Q==
+  dependencies:
+    "@aws-sdk/protocol-http" "3.171.0"
+    "@aws-sdk/signature-v4" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/util-arn-parser" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/signature-v4@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4/-/signature-v4-3.171.0.tgz#ac37c64abd93749e75655f6c832fa9070c7aad08"
+  integrity sha512-tun1PIN/zW2y3h6uYuGhDLaMQmT52KK3KZyq+UM2XLYPz8j7G2TEFyJVn5Wk+QbHirCmOh8dCkaa5yFO6vfEFw==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "3.170.0"
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/util-hex-encoding" "3.170.0"
+    "@aws-sdk/util-middleware" "3.171.0"
+    "@aws-sdk/util-uri-escape" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/smithy-client@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/smithy-client/-/smithy-client-3.171.0.tgz#1844e80f5612f87b3ac814a14e422f8bf8a094c4"
+  integrity sha512-Q4fYE8uWxDh1Pd9Flo7/Cns1eEg0PmPrMsgHv0za1S3TgVHA6jRq3KZaD6Jcm0H12NPbWv67Cu+O0sMei8oaxA==
+  dependencies:
+    "@aws-sdk/middleware-stack" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/types@3.171.0", "@aws-sdk/types@^3.1.0", "@aws-sdk/types@^3.110.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.171.0.tgz#2463d655636cbcf9cf5bb01d02d8217a5975948a"
+  integrity sha512-Yv5Wn/pbjMBST2jPHWPczmVbOLq8yFQVRyy1zGfsg1ETn25nGPvGBwqOkWcuz229KAcdUvFdRV9xaQCN3Lbo+Q==
+
+"@aws-sdk/url-parser@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/url-parser/-/url-parser-3.171.0.tgz#d8f0cde5f01798baf81fa7a54f7cf93c5be35ffa"
+  integrity sha512-EF4ecSTmW9yG1faCXpTvySIpaPhK+6ebVxT6Zlt7IwIb9K+0zWlNb6VjDzq5Xg+nK7Y1p7RGmwhictWbOtbo9g==
+  dependencies:
+    "@aws-sdk/querystring-parser" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-arn-parser@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-arn-parser/-/util-arn-parser-3.170.0.tgz#42587a958fd892ae51a447606e34ab5614bcb616"
+  integrity sha512-2ivABL9GNsucfMMkgGjVdFidbDogtSr4FBVW12D4ltijOL82CAynGrnxHAczRGnmi5/1/Ir4ipkr9pAdRMGiGw==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-base64-browser@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-browser/-/util-base64-browser-3.170.0.tgz#3352aeb2891f650fa0eda75d8be38ebdc6f98b43"
+  integrity sha512-uLP9Kp74+jc+UWI392LSWIaUj9eXZBhkAiSm8dXAyrr+5GFOKvmEdidFoZKKcFcZ2v3RMonDgFVcDBiZ33w7BQ==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-base64-node@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-base64-node/-/util-base64-node-3.170.0.tgz#434f719d467e04f553f3dc8991aec40483078607"
+  integrity sha512-sjpOmfyW0RWCLXU8Du0ZtwgFoxIuKQIyVygXJ4qxByoa3jIUJXf4U33uSRMy47V3JoogdZuKSpND9hiNk2wU4w==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-body-length-browser@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.170.0.tgz#4f88ad2493e7088a8b22972d4ff512a64f02fc7b"
+  integrity sha512-SqSWA++gsZgHw6tlcEXx9K6R6cVKNYzOq6bca+NR7jXvy1hfqiv9Gx5TZrG4oL4JziP8QA0fTklmI1uQJ4HBRA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-body-length-node@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-body-length-node/-/util-body-length-node-3.170.0.tgz#ef69fc0895338c2b15b5b4c9b201e72d4232cba1"
+  integrity sha512-sFb85ngsgfpamwDn22LC/+FkbDTNiddbMHptkajw+CAD2Rb4SJDp2PfXZ6k883BueJWhmxZ9+lApHZqYtgPdzw==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-buffer-from@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-buffer-from/-/util-buffer-from-3.170.0.tgz#efa9e74cd6fda5d711a99dc8a6f288afabe3b9fe"
+  integrity sha512-3ClE3wgN/Zw0ahfVAY5KQ/y3K2c+SYHwVUQaGSuVQlPOCDInGYjE/XEFwCeGJzncRPHIKDRPEsHCpm1uwgwEqQ==
+  dependencies:
+    "@aws-sdk/is-array-buffer" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-config-provider@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-config-provider/-/util-config-provider-3.170.0.tgz#85ad4dfa8102fe44b737c0aee23e63ae37ff9022"
+  integrity sha512-VV6lfss6Go00TF2hRVJnN8Uf2FOwC++1e8glaeU7fMWluYCBjwl+116mPOPFaxvkJCg0dui2tFroXioslM/rvQ==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-defaults-mode-browser@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.171.0.tgz#cd27a5daddc2a842c0eb0aa2b3d818b43cde18fa"
+  integrity sha512-ZZwtpm2XHTOx5TW7gQrpY+IOtriI506ab5t0DVgdOA7G8BVkC0I6Tm+0NJFSfsl/G4QzI0fNSbDG/6wAFZmPAQ==
+  dependencies:
+    "@aws-sdk/property-provider" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    bowser "^2.11.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-defaults-mode-node@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.171.0.tgz#15211dd8ce641da51bee3d269e6aab97701726b0"
+  integrity sha512-3zbtGGRfygZRIh6BtGm6S+qGPPF3l/kUH4FKY4zpfLFamv+8SpcAlqH5BmbayA77vHdtiGEo5PhnuEr6QRABkw==
+  dependencies:
+    "@aws-sdk/config-resolver" "3.171.0"
+    "@aws-sdk/credential-provider-imds" "3.171.0"
+    "@aws-sdk/node-config-provider" "3.171.0"
+    "@aws-sdk/property-provider" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-hex-encoding@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.170.0.tgz#e81f0fd8c951e0da7ada8d3148ead9b15c57f2f8"
+  integrity sha512-BDYyMqaxX4/N7rYOIYlqgpZaBuHw3kNXKgOkWtJdzndIZbQX8HnyJ+rF0Pr1aVsOpVDM+fY1prERleFh/ZRTCg==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-locate-window@^3.0.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-locate-window/-/util-locate-window-3.170.0.tgz#acc8717abe1e568de41d9b8ede33a49c6c1e108d"
+  integrity sha512-uQvn3ZaAokWcNSY+tNR71RGXPPncv5ejrpGa/MGOCioeBjkU5n5OJp7BdaTGouZu4fffeVpdZJ/ZNld8LWMgLw==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-middleware@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-middleware/-/util-middleware-3.171.0.tgz#1627cf129c79131b77d17738d970926322ffa8fd"
+  integrity sha512-43aXJ40z7BIkh6usI8qQlQ6JUj16ecmwsRmUi+SJf3+bHPnkENdjpKCx4i15UWii7fr5QJAivZykuvBXl/sicQ==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-stream-browser@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-stream-browser/-/util-stream-browser-3.171.0.tgz#b00ca482931dec98037e7209c5f721b1dfd2266c"
+  integrity sha512-GJfuRrAW+hwQfeWK3OfmN1kUtTpvVZj+EVb0GQ8F4/+PYRSpbNoQEW6oKCP6xIGR1xKLuiGsN5VQlWuECgIJKA==
+  dependencies:
+    "@aws-sdk/fetch-http-handler" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/util-base64-browser" "3.170.0"
+    "@aws-sdk/util-hex-encoding" "3.170.0"
+    "@aws-sdk/util-utf8-browser" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-stream-node@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-stream-node/-/util-stream-node-3.171.0.tgz#a20db66ad953ee6e3add503cbfbaa74603988e53"
+  integrity sha512-XuEUlixZnwqc1HSIRLFzIlfbpwMdAmGUkcADyvUYeTAEYf3hHzvvWERno4ZinuGQdU/+ogW29CsbTFnA80mz+A==
+  dependencies:
+    "@aws-sdk/node-http-handler" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    "@aws-sdk/util-buffer-from" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-uri-escape@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-uri-escape/-/util-uri-escape-3.170.0.tgz#1121fb47a59dab0f732b881742e9871c3690367c"
+  integrity sha512-Fof0urZ3Lx6z6LNKSEO6T4DNaNh6sLJaSWFaC6gtVDPux/C3R7wy2RQRDp0baHxE8m1KMB0XnKzHizJNrbDI1w==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-user-agent-browser@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.171.0.tgz#ea0d5204bc0a62ef5e26528693afc1938fe9b2df"
+  integrity sha512-DNps82f+fOOySUO49I8kAJIGdTtZiL0l3hPEY1V9vp4SbF8B1jbFjPRR24tRN1S0B9AfC78k0EmJTmNWvq6EBQ==
+  dependencies:
+    "@aws-sdk/types" "3.171.0"
+    bowser "^2.11.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-user-agent-node@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.171.0.tgz#61aa8c29a86a72e7fe6dd91b064cfc56c47c7e22"
+  integrity sha512-xyBOIA2UUoP6dWkxkxpJIQq2zt3PhZoIlMcFwcVPfKtnqOM0FzdTlUPN4iqi7UAOkKg020lZhflzMqu5454Ucg==
+  dependencies:
+    "@aws-sdk/node-config-provider" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-utf8-browser@3.170.0", "@aws-sdk/util-utf8-browser@^3.0.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.170.0.tgz#3fcea278e7a6fca4fef3d562300a3eea9a2f244f"
+  integrity sha512-tJby9krepSwDsBK+KQF5ACacZQ4LH1Aheh5Dy0pghxsN/9IRw7kMWTumuRCnSntLFFphDD7GM494/Dvnl1UCLA==
+  dependencies:
+    tslib "^2.3.1"
+
+"@aws-sdk/util-utf8-node@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-utf8-node/-/util-utf8-node-3.170.0.tgz#8f46d05bc887a7a8e3372a25e0f46035290a9aad"
+  integrity sha512-52QWGNoNQoyT2CuoQz6LjBKxHQtN/ceMFLW+9J1E0I1ni8XTuTYP52BlMe5484KkmZKsHOm+EWe4xuwwVetTxg==
+  dependencies:
+    "@aws-sdk/util-buffer-from" "3.170.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/util-waiter@3.171.0":
+  version "3.171.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-waiter/-/util-waiter-3.171.0.tgz#94b5e506c9b08713d44c593c36ff9d44773dc0b1"
+  integrity sha512-h4iqRxX09tM9yjnHWihnzM5cDboSEJAbx68ar4zjzDIUbVroVkDfl77AWVlS9D5SlfdWr70G3WT4EQfIK5Vd2g==
+  dependencies:
+    "@aws-sdk/abort-controller" "3.171.0"
+    "@aws-sdk/types" "3.171.0"
+    tslib "^2.3.1"
+
+"@aws-sdk/xml-builder@3.170.0":
+  version "3.170.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.170.0.tgz#bee57bd55db4003bbd09ca3d2fa7a001b24ed21c"
+  integrity sha512-eN458rrukeI62yU1k4a+032IfpAS7aK30VEITzKanklMW6AxTpxUC6vGrP6bwtIpCFDN8yVaIiAwGXQg5l1X4g==
+  dependencies:
+    tslib "^2.3.1"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
@@ -5926,6 +6820,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bowser@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.11.0.tgz#5ca3c35757a7aa5771500c70a73a9f91ef420a8f"
+  integrity sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==
+
 boxen@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-5.1.2.tgz#788cb686fc83c1f486dfa8a40c68fc2b831d2b50"
@@ -6112,6 +7011,14 @@ buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
+
+buffer@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
 
 buffer@6.0.3:
   version "6.0.3"
@@ -7936,7 +8843,7 @@ enhanced-resolve@^5.9.3:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-entities@^2.0.0:
+entities@2.2.0, entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
@@ -8457,7 +9364,7 @@ eventemitter3@^4.0.4:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events@^3.0.0, events@^3.2.0:
+events@3.3.0, events@^3.0.0, events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -8699,6 +9606,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-xml-parser@3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
+  integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
 
 fastest-levenshtein@^1.0.16:
   version "1.0.16"
@@ -10024,7 +10936,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.0, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -14316,7 +15228,7 @@ read-pkg@^5.2.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@^3.4.0, readable-stream@^3.5.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -15503,6 +16415,14 @@ storybook-css-modules-preset@^1.1.1:
   resolved "https://registry.yarnpkg.com/storybook-css-modules-preset/-/storybook-css-modules-preset-1.1.1.tgz#30310eab3c324cb944ea760ecd73b5341bcae6c6"
   integrity sha512-wyINPOtB/8SvU7J92ePAhciBk4xoHuwrcqDNyGnSwilwHjmtHwbeEgZ1//JALOTwMB10zwz3WPONRkWec9LdGw==
 
+stream-browserify@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-3.0.0.tgz#22b0a2850cdf6503e73085da1fc7b7d0c2122f2f"
+  integrity sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==
+  dependencies:
+    inherits "~2.0.4"
+    readable-stream "^3.5.0"
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
@@ -16377,12 +17297,12 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@~2.4.0:
+tslib@^2, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==


### PR DESCRIPTION
👉 This PR adds a new feature: upload files on a S3 (protocol) server like Minio.

🧠 This new feature is implemented under hexagonal architecture and event sourcing principles: the main idea beeing to create a "contract" between hexagone (core) and outside (a FilePort) that will be implemented by any gateway (the outside).

✅ What have been added (not limited list 😌)?

- the `File` port (interfaces which must be implemented by adapters)
- a `FileRegistryGateway` that allows to register any kind of gateway that implements the port via a strategy pattern
- a `S3FileGateway` that allows to upload a file and track its progression on any S3 based server
- a `UploadFiles` command (use-case) that will orchestrate the whole asynchronous process thanks to an `execute` function that guarantees that all operations are executed in the **same session** (e.g if a gateway needs a websocket connection, that guarantees that the connection / upload / ... / closing are executed in the same session)
- a complete error management that can catch any error in the upload process, from invoking the command to executing the upload operation on server
- a complete task tracking that offers, for each file to upload, the capability to track the whole asynchronous progress (e.g track the bytes sent / stream)
- some modifications in the file store to accept `dependencies` in the `ThunkMiddleware`
- some new store selectors to compute file sizes or to access an array of current tasks 
- some minor refactoring to handle the changes

🧪The whole behavior in under unit-testing (`UploadFiles` as SUT)

⚠️ There is no test suite for the `task` primary adapters because I had to hack the way command are invoked by creating fake events that are not Event Sourcing based... THIS WILL BE REPLACED WITH THE COMMAND BUS 😎

❤️ The port is protocol agnostic, so it will be easy to add an `IPFS` gateway in a very soon future!