### PR TITLE
Fix: show code button not working on select story

### DIFF
--- a/stories/molecules/components/select/select.scss
+++ b/stories/molecules/components/select/select.scss
@@ -5,7 +5,6 @@ div {
       overflow: visible;
       > div:first-child {
         overflow: visible;
-        z-index: 2;
       }
       > div:nth-child(2) {
         bottom: 10px;


### PR DESCRIPTION
The "Show Code" button in the story about the `Select` component was not working anymore because I modified a z-index.
The select menu is well displayed without the z-index property so I just removed it.
