### PR TITLE
Feat: change mandatory firstElement property to optional

### DIFF
--- a/src/ui/molecules/header/Header.tsx
+++ b/src/ui/molecules/header/Header.tsx
@@ -10,7 +10,7 @@ export type HeaderProps = {
   /**
    * Element positioned first in the reading flow.
    */
-  readonly firstElement: JSX.Element
+  readonly firstElement?: JSX.Element
   /**
    * The list of navigable links that make up the menu.
    */
@@ -81,13 +81,12 @@ export const Header: React.FC<HeaderProps> = ({
   const showRowMenu = !isSmallScreen && !!navigationMenu
   const showBurgerMenuList = showBurgerMenu && isBurgerMenuOpen
 
-  const headerClassname = classNames(
-    'okp4-header-main',
-    navigationMenu ? 'with-navigation' : 'without-navigation',
-    {
-      'burger-list': showBurgerMenuList
-    }
-  )
+  const headerClassname = classNames('okp4-header-main', {
+    'with-first-element': firstElement && !navigationMenu,
+    'with-navigation': !firstElement && navigationMenu,
+    'with-first-element-and-navigation': firstElement && navigationMenu,
+    'burger-list': showBurgerMenuList
+  })
 
   const toggleBurgerMenu = useCallback((): void => {
     setIsBurgerMenuOpen(!isBurgerMenuOpen)
@@ -101,7 +100,7 @@ export const Header: React.FC<HeaderProps> = ({
     <div className={headerClassname}>
       {showBurgerMenu && <BurgerMenu isOpen={isBurgerMenuOpen} onToggle={toggleBurgerMenu} />}
       {showBurgerMenuList && <NavigationMenu navigation={navigationMenu} withBurgerMenu />}
-      <FirstElement firstElement={firstElement} hasBurger={showBurgerMenu} />
+      {firstElement && <FirstElement firstElement={firstElement} hasBurger={showBurgerMenu} />}
       {showRowMenu && <NavigationMenu navigation={navigationMenu} />}
       <ThemeSwitcher className={classNames({ 'with-navigation': !!navigationMenu })} />
     </div>

--- a/src/ui/molecules/header/header.scss
+++ b/src/ui/molecules/header/header.scss
@@ -1,18 +1,72 @@
 @import '../../styles/themes.scss';
+@import '../../styles/animations.scss';
 
-@keyframes fadeIn {
-  0% {
-    opacity: 0;
+@mixin first-element {
+  grid-column: 1;
+
+  @media screen and (max-width: 360px) {
+    justify-self: center;
   }
 
-  100% {
-    opacity: 1;
+  :first-child {
+    max-width: 270px;
+    max-height: 72px;
+
+    @media screen and (max-width: 550px) {
+      max-width: 250px;
+    }
+
+    @media screen and (max-width: 480px) {
+      max-width: 220px;
+    }
+  }
+}
+
+@mixin burger-menu {
+  grid-area: 1 / 1;
+  width: fit-content;
+  cursor: pointer;
+
+  &.rotate-down {
+    transform: rotate(90deg);
+    transition: transform 0.1s linear;
+  }
+
+  &.rotate-up {
+    transform: rotate(0deg);
+    transition: transform 0.1s linear;
+  }
+}
+
+@mixin navigation-row-list {
+  display: flex;
+  justify-content: space-evenly;
+  margin: 0 20px;
+
+  .okp4-header-navigation-row-item {
+    margin-left: 10px;
+  }
+}
+
+@mixin burger-list-container {
+  grid-template-rows: auto 1fr;
+  background-color: themed('header-navigation-background');
+  box-shadow: 10px 10px 10px themed('header-navigation-background');
+}
+
+@mixin burger-list {
+  margin: 10px 0 10px 10px;
+  animation: fadeIn 1s;
+
+  .okp4-header-navigation-burger-item {
+    margin-top: 20px;
   }
 }
 
 .okp4-header-main {
   @include with-theme() {
     display: grid;
+    grid-column: 1;
     width: calc(100% - 120px);
     padding: 15px 60px;
     align-items: center;
@@ -28,7 +82,11 @@
       padding: 15px;
     }
 
-    &.without-navigation {
+    .okp4-header-theme-switcher-container {
+      justify-self: flex-end;
+    }
+
+    &.with-first-element {
       grid-template-columns: auto auto;
 
       @media screen and (max-width: 768px) {
@@ -36,100 +94,85 @@
       }
 
       @media screen and (max-width: 360px) {
-        grid-template: 2fr 1fr / 1fr;
-        justify-items: center;
-        row-gap: 10px;
+        grid-template: 1fr 1fr / 1fr;
+      }
+
+      .okp4-header-first-element {
+        @include first-element;
+      }
+
+      .okp4-header-theme-switcher-container {
+        grid-column: 2;
+
+        @media screen and (max-width: 360px) {
+          grid-area: 2 / 1;
+          justify-self: center;
+        }
       }
     }
 
     &.with-navigation {
+      grid-template-columns: 2fr 1fr;
+
+      &.burger-list {
+        @include burger-list-container;
+
+        .okp4-header-navigation-burger-list {
+          @include burger-list;
+          grid-area: 2 / 1 / 2 / 3;
+        }
+      }
+
+      .okp4-header-navigation-burger-menu {
+        @include burger-menu;
+      }
+
+      .okp4-header-navigation-row-list {
+        @include navigation-row-list;
+        grid-column: 1;
+      }
+
+      .okp4-header-theme-switcher-container {
+        grid-column: 2;
+      }
+    }
+
+    &.with-first-element-and-navigation {
       grid-template-columns: auto 2fr 1fr;
 
       @media screen and (max-width: 995px) {
         grid-template-columns: repeat(3, 1fr);
       }
 
+      .okp4-header-first-element {
+        @include first-element;
+
+        @media screen and (max-width: 995px) {
+          grid-area: 1 / 2;
+          justify-self: center;
+        }
+      }
+
       &.burger-list {
-        grid-template-rows: auto 1fr;
-        background-color: themed('header-navigation-background');
-        box-shadow: 10px 10px 10px themed('header-navigation-background');
+        @include burger-list-container;
 
         .okp4-header-navigation-burger-list {
+          @include burger-list;
           grid-area: 2 / 1 / 2 / 4;
-          margin: 10px 0 10px 10px;
-          animation: fadeIn 1s;
-
-          .okp4-header-navigation-burger-item {
-            margin-top: 20px;
-          }
         }
       }
 
       .okp4-header-navigation-burger-menu {
-        grid-area: 1 / 1;
-        width: fit-content;
-        cursor: pointer;
-
-        &.rotate-down {
-          transform: rotate(90deg);
-          transition: transform 0.1s linear;
-        }
-
-        &.rotate-up {
-          transform: rotate(0deg);
-          transition: transform 0.1s linear;
-        }
+        @include burger-menu;
       }
 
       .okp4-header-navigation-row-list {
+        @include navigation-row-list;
         grid-area: 1 / 2;
-        display: flex;
-        justify-content: space-evenly;
-        margin: 0 20px;
-
-        .okp4-header-navigation-row-item {
-          margin-left: 10px;
-        }
-      }
-    }
-
-    .okp4-header-first-element {
-      grid-column: 1;
-
-      @media screen and (max-width: 768px) {
-        justify-self: center;
       }
 
-      :first-child {
-        max-width: 270px;
-        max-height: 72px;
-
-        @media screen and (max-width: 550px) {
-          max-width: 250px;
-        }
-
-        @media screen and (max-width: 480px) {
-          max-width: 220px;
-        }
-      }
-
-      &.with-burger {
-        grid-area: 1 / 2;
-        justify-self: center;
-      }
-    }
-
-    .okp4-header-theme-switcher-container {
-      justify-self: flex-end;
-      grid-column: 2;
-
-      @media screen and (max-width: 360px) {
-        grid-area: 2/1;
-        justify-self: unset;
-      }
-
-      &.with-navigation {
-        grid-area: 1 / 3;
+      .okp4-header-theme-switcher-container {
+        grid-column: 3;
       }
     }
   }

--- a/src/ui/styles/animations.scss
+++ b/src/ui/styles/animations.scss
@@ -59,3 +59,13 @@
     transform: translateY(-3px);
   }
 }
+
+@keyframes fadeIn {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}

--- a/stories/molecules/components/header/Header.stories.mdx
+++ b/stories/molecules/components/header/Header.stories.mdx
@@ -76,7 +76,7 @@ import './header.scss'
 
 ## First element
 
-**firstElement** allows the user to put any type of element in the `header`.  
+Optional **firstElement** allows the user to put any type of element in the `header`.  
 The size of the element is limited to a `max height` of `72px` and a responsive
 `max width` of `270px` and `220px` to limit its size, making sure injected
 elements conform to the layout.
@@ -103,6 +103,39 @@ This responsive menu provides the user with a set of navigable links and greatly
 
 You just have to provide it with an array of `JSX.Element` which will then be displayed on a single line on a large or medium screen, or accessible via a burger menu on a smaller or mobile screen.  
 Please shorten the window to let the magic happen!
+
+#### Navigation menu
+
+<Canvas>
+  <Story name="Navigation menu without first element">
+    {() => {
+      const changeHeaderDisplay = useMediaType('(max-width: 995px)')
+      const links = [
+        { name: 'Welcome', url: 'https://ui.okp4.space/?path=/docs/welcome--page' },
+        { name: 'Philosophy', url: 'https://ui.okp4.space/?path=/docs/philosophy--page' },
+        { name: 'Start', url: 'https://ui.okp4.space/?path=/docs/getting-started--page' },
+        {
+          name: 'Languages',
+          url: 'https://ui.okp4.space/?path=/docs/guidelines-internationalization--page'
+        },
+        {
+          name: 'Responsiveness',
+          url: 'https://ui.okp4.space/?path=/docs/guidelines-responsive-web-design--page'
+        }
+      ]
+      const navigationMenu = links.map(link => (
+        <Typography as="div" fontSize="small" fontWeight="bold">
+          <a href={link.url} target="_blank" style={{ wordBreak: 'normal' }}>
+            {link.name}
+          </a>
+        </Typography>
+      ))
+      return <Header navigationMenu={navigationMenu} />
+    }}
+  </Story>
+</Canvas>
+
+#### Navigation menu with first element
 
 <Canvas>
   <Story name="Navigation menu">
@@ -135,6 +168,17 @@ Please shorten the window to let the magic happen!
         />
       )
     }}
+  </Story>
+</Canvas>
+
+## Header with theme switcher only
+
+All the properties of the **Header** being optional, it can only contain the `ThemeSwitcher` which is directly integrated.  
+In this case, it simply looks like this:
+
+<Canvas>
+  <Story name="Header with them switcher only">
+    <Header />
   </Story>
 </Canvas>
 


### PR DESCRIPTION
This PR makes the `firstElement` property optional because there was no reason to force the user to provide this property.
The `Header` no longer has any mandatory properties.
🛠 The css has been completely reworked to facilitate the possible extension of the `Header` properties: 
👉 if we plan to add a `Login` element in JSX, this addition will not force us to modify the existing but to add a behavior.
