### PR TITLE
fix: fix i18n import

### DIFF
--- a/src/domain/error/index.ts
+++ b/src/domain/error/index.ts
@@ -1,4 +1,4 @@
-import 'i18n/index'
+import './i18n/index'
 export * from './store/builder/store.builder'
 export * from './store/selector/error.selector'
 export * from './usecase/index'


### PR DESCRIPTION
Fix (restore) incorrect aliased import introduced by [#580](https://github.com/okp4/ui/pull/580/files#diff-3c486c63778bc259b34e6cb6c8b44f75eab15770a65456b1933f21920733cc27) which no longer imports translations in the domain `error`.

This leads the [faucet-web](https://faucet.okp4.network) (in prod) to display this (for almost all errors): 

<img width="429" alt="image" src="https://user-images.githubusercontent.com/9574336/197361239-eb76ab5b-8e07-4fbc-b01a-892e2043d414.png">

And the [design system storybook](https://ui.okp4.space) as well.

<img width="1247" alt="image" src="https://user-images.githubusercontent.com/9574336/197361754-982ee5a0-3341-4d51-8e80-45ae9007bde4.png">
