### PR TITLE
Fix/faucet connection error

### DIFF
--- a/src/adapters/faucet/secondary/graphql/client.ts
+++ b/src/adapters/faucet/secondary/graphql/client.ts
@@ -7,6 +7,7 @@ import type {
   SubscriptionOperation
 } from '@urql/core/dist/types/exchanges/subscription'
 import type { DeepReadonly } from 'superTypes'
+import { FaucetConnectionError } from 'domain/faucet/entity/error'
 
 const urlReg = new RegExp('^(?<scheme>[a-z][a-z0-9+\\-.]*)://(?<target>.*)$')
 
@@ -25,7 +26,7 @@ const client = async (url: string): Promise<FaucetClient> => {
   return new Promise<GQLWSClient>(
     (
       resolve: (gqlWsClient: DeepReadonly<GQLWSClient>) => void,
-      reject: (reason: string) => void
+      reject: (reason: DeepReadonly<FaucetConnectionError>) => void
     ) => {
       const wsClient = createWSClient({
         url: makeWSURL(url),
@@ -33,7 +34,7 @@ const client = async (url: string): Promise<FaucetClient> => {
         on: {
           error: () => {
             wsClient.terminate()
-            reject('GQLWS client failed to connect')
+            reject(new FaucetConnectionError('GQLWS client failed to connect'))
           },
           connected: () => {
             resolve(wsClient)

--- a/src/domain/error/i18n/errorDomain_en.json
+++ b/src/domain/error/i18n/errorDomain_en.json
@@ -7,7 +7,8 @@
       "bech32-error": "Please enter an address that conforms to bech32 format and begins with okp4.",
       "faucet-gateway-error": "Oops, an error occurred while sending you your Know. $t(errorDomain:domain.error.contact-us)",
       "keplr-extension-unavailable-error": "The Keplr extension must be installed and activated in your browser in order to use it.",
-      "chain-suggestion-error": "Failed to suggest the chain. $t(errorDomain:domain.error.contact-us)"
+      "chain-suggestion-error": "Failed to suggest the chain. $t(errorDomain:domain.error.contact-us)",
+      "faucet-connection-error": "Failed to connect. This may be related to the limitation of the number of requests (you can only make one request per hour)."
     }
   }
 }

--- a/src/domain/error/i18n/errorDomain_fr.json
+++ b/src/domain/error/i18n/errorDomain_fr.json
@@ -7,7 +7,8 @@
       "bech32-error": "Merci de saisir une adresse conforme au format bech32 et qui débute par okp4.",
       "faucet-gateway-error": "Oups, une erreur s'est produite en vous envoyant votre Know. $t(errorDomain:domain.error.contact-us)",
       "keplr-extension-unavailable-error": "L'extension Keplr doit être installée et activée dans votre navigateur pour pouvoir l'utiliser.",
-      "chain-suggestion-error": "Échec de la suggestion de la chaîne. $t(errorDomain:domain.error.contact-us)"
+      "chain-suggestion-error": "Échec de la suggestion de la chaîne. $t(errorDomain:domain.error.contact-us)",
+      "faucet-connection-error": "Echec de connection. Cela peut être lié à la limitation du nombre de requêtes (vous ne pouvez faire qu'une requête par heure)."
     }
   }
 }

--- a/src/domain/faucet/entity/error.ts
+++ b/src/domain/faucet/entity/error.ts
@@ -16,3 +16,9 @@ export class Bech32Error extends Error {
     this.name = 'Bech32Error'
   }
 }
+export class FaucetConnectionError extends Error {
+  constructor(message?: string) {
+    super(message)
+    this.name = 'FaucetConnectionError'
+  }
+}


### PR DESCRIPTION
This PR aims to fix the way connection errors are caught by the faucet client, by:

- adding a new `FaucetConnectionError` dedicated to the GQLWS failure
- translating error into a readable message (generic)