### PR TITLE
Feat/use official keplr link

### DIFF
--- a/src/ui/organisms/faucet/Faucet.tsx
+++ b/src/ui/organisms/faucet/Faucet.tsx
@@ -159,7 +159,7 @@ export const Faucet: React.FC<FaucetProps> = ({ chainId }: FaucetProps) => {
             <Typography as="span" color="text" fontSize="x-small" fontWeight="bold">
               <a
                 className="okp4-faucet-content-info-link"
-                href="https://chrome.google.com/webstore/detail/keplr/dmkamcknogkgcdfhhbddcghachkejeap"
+                href="https://www.keplr.app/download"
                 rel="noreferrer"
                 target="_blank"
               >

--- a/stories/organisms/components/faucet/Faucet.stories.mdx
+++ b/stories/organisms/components/faucet/Faucet.stories.mdx
@@ -48,7 +48,7 @@ The `Faucet` is a complete organism that brings to the user an interface allowin
 
 The organism embeds all the business logic, including the connection to the Keplr wallet and the management of request for tokens sent to the [Faucet service](https://github.com/okp4/cosmos-faucet).
 
-For the OKP4 testnets, the Faucet service is configured to send 1 KNOW per request, with a maximum of 1 request each 5 seconds. To get some KNOWs, you just need to enter your OKP4 address or connect via [Keplr](https://chrome.google.com/webstore/detail/keplr/dmkamcknogkgcdfhhbddcghachkejeap), the OKP4 wallet!
+For the OKP4 testnets, the Faucet service is configured to send 1 $KNOW per request, with a maximum of 1 request each 5 seconds. To get some KNOWs, you just need to enter your OKP4 address or connect via [Keplr](https://www.keplr.app).
 
 ## Overview
 


### PR DESCRIPTION
Self explanatory. Better to use official [Keplr](https://www.keplr.app/) URLs.