### PR TITLE
fix: couple select value props with select value hook

### DIFF
--- a/src/ui/molecules/select/Select.tsx
+++ b/src/ui/molecules/select/Select.tsx
@@ -179,6 +179,10 @@ export const Select = ({
     }
   }, [menuOpened])
 
+  useEffect(() => {
+    setSelectValue(value)
+  }, [value])
+
   return (
     <div
       className={classNames(`okp4-select-container ${size}`, {


### PR DESCRIPTION
This PR fixes the problem of the select component hook not updating when the value prop is updated