### PR TITLE
refactor(context): import `Context` type and `createContext` from React

### DIFF
--- a/src/context/storeContext/errorContext.ts
+++ b/src/context/storeContext/errorContext.ts
@@ -1,8 +1,9 @@
-import React from 'react'
+import { createContext } from 'react'
 import type { ReactReduxContextValue } from 'react-redux'
 import type { AppState } from 'domain/error/store/appState'
+import type { Context } from 'react'
 
-export const ErrorContext = React.createContext(null) as unknown as React.Context<
+export const ErrorContext = createContext(null) as unknown as Context<
   // Need any type for Action to allow Redux to dispatch async Thunks
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ReactReduxContextValue<AppState, any>

--- a/src/context/storeContext/faucetContext.ts
+++ b/src/context/storeContext/faucetContext.ts
@@ -1,8 +1,9 @@
-import React from 'react'
+import { createContext } from 'react'
 import type { ReactReduxContextValue } from 'react-redux'
 import type { AppState } from 'domain/faucet/store/appState'
+import type { Context } from 'react'
 
-export const FaucetContext = React.createContext(null) as unknown as React.Context<
+export const FaucetContext = createContext(null) as unknown as Context<
   // Need any type for Action to allow Redux to dispatch async Thunks
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ReactReduxContextValue<AppState, any>

--- a/src/context/storeContext/fileContext.ts
+++ b/src/context/storeContext/fileContext.ts
@@ -1,8 +1,9 @@
-import React from 'react'
+import { createContext } from 'react'
 import type { ReactReduxContextValue } from 'react-redux'
 import type { AppState } from 'domain/file/store/appState'
+import type { Context } from 'react'
 
-export const FileContext = React.createContext(null) as unknown as React.Context<
+export const FileContext = createContext(null) as unknown as Context<
   // Need any type for Action to allow Redux to dispatch async Thunks
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ReactReduxContextValue<AppState, any>

--- a/src/context/storeContext/taskContext.ts
+++ b/src/context/storeContext/taskContext.ts
@@ -1,8 +1,9 @@
-import React from 'react'
+import { createContext } from 'react'
 import type { ReactReduxContextValue } from 'react-redux'
 import type { AppState } from 'domain/task/store/appState'
+import type { Context } from 'react'
 
-export const TaskContext = React.createContext(null) as unknown as React.Context<
+export const TaskContext = createContext(null) as unknown as Context<
   // Need any type for Action to allow Redux to dispatch async Thunks
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ReactReduxContextValue<AppState, any>

--- a/src/context/storeContext/walletContext.ts
+++ b/src/context/storeContext/walletContext.ts
@@ -1,8 +1,9 @@
-import React from 'react'
+import { createContext } from 'react'
 import type { ReactReduxContextValue } from 'react-redux'
 import type { AppState } from 'domain/wallet/store/appState'
+import type { Context } from 'react'
 
-export const WalletContext = React.createContext(null) as unknown as React.Context<
+export const WalletContext = createContext(null) as unknown as Context<
   // Need any type for Action to allow Redux to dispatch async Thunks
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ReactReduxContextValue<AppState, any>

--- a/src/context/themeContext.ts
+++ b/src/context/themeContext.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import { createContext } from 'react'
 
 export type Theme = 'light' | 'dark'
 export type ThemeContextType = Readonly<{
@@ -6,5 +6,5 @@ export type ThemeContextType = Readonly<{
   setTheme: (newTheme: Theme) => void
 }>
 
-const ThemeContext = React.createContext<ThemeContextType | null>(null)
+const ThemeContext = createContext<ThemeContextType | null>(null)
 export default ThemeContext


### PR DESCRIPTION
In the same line of the [MR](https://github.com/okp4/ui/pull/663), here is a slight refactoring of the context folder.